### PR TITLE
feat: 리액트라우트 이용, 내 정보 보기 페이지 이동 버튼 추가

### DIFF
--- a/src/components/Topbar.js
+++ b/src/components/Topbar.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import DeveloperModeIcon from '@mui/icons-material/DeveloperMode';
 import { useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
 
 import { login, logout } from '../features/userSlice';
 
@@ -9,6 +10,8 @@ import Button from './Button';
 import './Topbar.scss';
 
 export default function Topbar() {
+  const userId = useSelector((state) => state.user.uid);
+
   const isLoggedIn = useSelector((state) => state.user.isLoggedIn);
   const dispatch = useDispatch();
   const handleLoginButtonClick = () => {
@@ -27,6 +30,9 @@ export default function Topbar() {
           </span>
         </div>
         <div className="topbar__right">
+          <Link to={`/users/${userId}`}>
+            <button>내 정보 보기</button>
+          </Link>
           {!isLoggedIn ? (
             <Button onClick={handleLoginButtonClick}>Google SignIn</Button>
           ) : (

--- a/src/components/Topbar.scss
+++ b/src/components/Topbar.scss
@@ -1,6 +1,6 @@
 .topbar {
   &__wrapper {
-    height: 100%;
+    height: 80px;
     padding: 0 20px;
     display: flex;
     align-items: center;


### PR DESCRIPTION
## 코드를 작성한 이유

- topbar에 유저의 자기 정보를 확인할 수 있는 페이지로 이동할 수 있는 버튼을 추가했습니다.

## 무엇이 변하였는가

- 리덕스 스토어에 저장된 user의 uid를 통해 url을 동적으로 변화시켜줬습니다. 
- 현재는 button으로 구현했지만 a태그를 활용해볼 생각입니다.

## 작성한 코드에 문제점이 존재하는가

- CSS, 스타일 문제

## 리뷰 중점사항 

- 버튼위치, url주소, 다른 api문제가 없는지 확인 부탁드립니다
