### PR TITLE
언어 선택 모달을 통해 연습으로 페이지가 이동할 수 있도록 구현함

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 import Home from '../pages/Home';
+import PracticePage from '../pages/PracticePage';
 import Userpage from '../pages/UserPage';
 
 import Menu from './Menu';
@@ -20,6 +21,10 @@ export default function Layout() {
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/users/:id" element={<Userpage />} />
+            <Route
+              path="/practice/:languages/:types"
+              element={<PracticePage />}
+            />
           </Routes>
         </main>
       </div>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -13,7 +13,7 @@ export default function Modal({ message, onCloseModal }) {
         >
           X
         </button>
-        <p className="modal__content">{message}</p>
+        <div className="modal__content">{message}</div>
       </div>
     </div>
   );

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,14 +1,33 @@
 import React, { useState } from 'react';
 
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+
 import Modal from '../components/Modal';
 import ModalPortal from '../ModalPortal';
 
 import './Home.scss';
 
 export default function Home() {
+  const navigate = useNavigate();
   const [isShowing, setIsShowing] = useState(false);
-  const openModal = () => {
+  const [language, setLanguage] = useState('');
+
+  const handleModalOpen = (lang, e) => {
+    setLanguage(lang);
     setIsShowing(true);
+  };
+
+  const handleWordButtnoCLick = () => {
+    navigate(`/practice/${language}/word`);
+  };
+
+  const handleSentenceButtnoCLick = () => {
+    navigate(`/practice/${language}/sentence`);
+  };
+
+  const handleParagraphButtnoCLick = () => {
+    navigate(`/practice/${language}/paragraph`);
   };
 
   return (
@@ -17,7 +36,11 @@ export default function Home() {
         <h1>Choose What You Want To Practice!</h1>
       </header>
       <section>
-        <article onClick={openModal}>
+        <article
+          onClick={(e) => {
+            handleModalOpen('C', e);
+          }}
+        >
           <h2>C</h2>
           <p>
             C언어는 현재 사용되고 있는 거의 모든 컴퓨터 시스템에서 사용할 수
@@ -27,7 +50,11 @@ export default function Home() {
             사용되는 프로그래밍 언어입니다.
           </p>
         </article>
-        <article>
+        <article
+          onClick={(e) => {
+            handleModalOpen('Python', e);
+          }}
+        >
           <h2>Python</h2>
           <p>
             파이썬은 1989년 귀도 반 로썸(Guido van Rossum)에 의해 개발된 고급
@@ -37,7 +64,11 @@ export default function Home() {
             대한민국 2015년 개정 교육과정에 포함되었습니다.
           </p>
         </article>
-        <article>
+        <article
+          onClick={(e) => {
+            handleModalOpen('JavaScript', e);
+          }}
+        >
           <h2>JavaScript</h2>
           <p>
             자바스크립트(JavaScript)는 객체(object) 기반의 스크립트 언어입니다.
@@ -52,7 +83,18 @@ export default function Home() {
       </section>
       {isShowing && (
         <ModalPortal>
-          <Modal message={'테스트입니다'} onCloseModal={setIsShowing} />
+          <Modal
+            message={
+              <div>
+                <button onClick={handleWordButtnoCLick}>낱말 연습</button>
+                <button onClick={handleSentenceButtnoCLick}>
+                  짧은 글 연습
+                </button>
+                <button onClick={handleParagraphButtnoCLick}>긴 글 연습</button>
+              </div>
+            }
+            onCloseModal={setIsShowing}
+          />
         </ModalPortal>
       )}
     </div>

--- a/src/pages/PracticePage.js
+++ b/src/pages/PracticePage.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { useParams } from 'react-router-dom';
+
+export default function PracticePage() {
+  const { languages, types } = useParams();
+
+  return <h1>hello world</h1>;
+}

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -32,7 +32,7 @@ export default function UserPage() {
     setSoundEffectsSetting(e.target.value === 'true');
   };
 
-  const hancleSettingSaveButtonClick = async () => {
+  const handleSettingSaveButtonClick = async () => {
     dispatch(
       changeSetting({ id, selectedLanguageSetting, soundEffectsSetting }),
     );
@@ -109,7 +109,7 @@ export default function UserPage() {
             Python
           </label>
         </div>
-        <button onClick={hancleSettingSaveButtonClick}>설정 저장하기</button>
+        <button onClick={handleSettingSaveButtonClick}>설정 저장하기</button>
       </div>
 
       <div>


### PR DESCRIPTION
## 코드를 작성한 이유

- 각 언어별 실제 연습 페이지로 이동할 수 있도록 해줄 필요성이 있었습니다.

## 무엇이 변하였는가

- 메인 화면에서 언어선택 버튼을 누르면 모달이 뜨는데. 모달 화면에 연습 종류 별 버튼이 뜨도록 하였습니다. 
또 버튼을 클릭할 경우 실제 언어별 및 연습 타입 별 페이지로 이동할 수 있도록 하였습니다.


## 작성한 코드에 문제점이 존재하는가

- 없습니다.

## 리뷰 중점사항 

- 이제 각 페이지별로 연습 데이터를 불러와야 할텐데, 이 점도 같이 생각해서 리뷰해주시면 감사하겠습니다.
