### PR TITLE
서버에 get 요청을 통해 db에 저장된 paragraphs 정보를 받아 긴글(paragraphs) 목록들을 화면에 뜨도록 코드 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5713,7 +5713,7 @@
         "prelude-ls": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
         },
         "source-map": {
           "version": "0.6.1",
@@ -10263,7 +10263,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picocolors": {
       "version": "1.0.0",
@@ -11166,7 +11166,7 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "6.5.3",

--- a/src/pages/PracticePage.js
+++ b/src/pages/PracticePage.js
@@ -1,16 +1,51 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
+import axios from 'axios';
 import { useSelector } from 'react-redux';
 import { useParams, Link } from 'react-router-dom';
 
 export default function PracticePage() {
   const { languages, types } = useParams();
   const { isLoggedIn } = useSelector((state) => state.user);
+  const [paragraphs, setParagraphs] = useState();
+
+  useEffect(() => {
+    const getParagraph = async () => {
+      const response = await axios.get(
+        process.env.REACT_APP_SERVER_URL + `/languages/${languages}`,
+        {
+          params: {
+            type: types,
+          },
+        },
+      );
+
+      setParagraphs(response.data);
+    };
+
+    getParagraph();
+  }, []);
 
   return (
     <div>
       {isLoggedIn ? (
-        <h1>hello world</h1>
+        <div>
+          <h1>hello world</h1>
+          <div>
+            {paragraphs?.map((list, index) => {
+              return (
+                <div key={index}>
+                  {list[languages]?.map((val, idx) => (
+                    <div style={{ whiteSpace: 'pre-wrap' }} key={idx}>
+                      {val}
+                      <div>-------------------------</div>
+                    </div>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+        </div>
       ) : (
         <div>
           <p>로그인 해야 합니다</p>


### PR DESCRIPTION
## 코드를 작성한 이유

- 사용자가 코드 연습을 하기 위해 긴글 연습을 클릭하여 해당 페이지로 접근하는 경우, 서버에 get 요청을 통해 db에 저장된 paragraphs 정보를 받아 긴글(paragraphs) 목록들을 화면에 뜨도록 하기위해 구현한 코드입니다.

## 무엇이 변하였는가

- 변한 부분은 axios.get 을 통해 서버에서 가져온 데이터를 useState를 이용해서 저장하여 그 긴글(paragraphs) 목록들을 화면에 보여주기 위한 코드를 작성한 것입니다.

## 작성한 코드에 문제점이 존재하는가

- 문제점은 없는 것 같은데 랜더링 횟수에 대해 한번 다시 확인해 보겠습니다.

## 리뷰 중점사항 

- 기존에 작성해주신 api.js 에서 getAxio 함수를 이용하고 싶었지만 params: {type: types} 를 사용하니 서버에 req.query.type은 undefined로 나타나서 사용하지 못하고 axios.get을 통해 문제를 일단 해결했습니다.
- `{list[languages]?.map((val, idx) => (` 이 코드에서 데이터를 받아오는 형태에 맞춰서 작성하다보니 조금 어색한 부분이 있어보이는데 확인해보시고 리뷰 부탁드립니다.
- `<div style={{ whiteSpace: 'pre-wrap' }} key={idx}>` 와 같이 style을 넣어 준 이유는 일단 저부분이 없으면 \t(탭) 과 \n(한줄띄우기) 부분이 적용되지 않고 화면에 나타나기때문에 style을 통해서 그런부분들을 해결하는 방법이 있긴해서 일단 적용시켜보았습니다. 추후에 다시 찾아보겠습니다.
