### PR TITLE
axios instance가 config 정보도 받을 수 있도록 리펙토링

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -9,8 +9,8 @@ export const setAxios = async (user) => {
   instance.defaults.headers.common['authorization'] = token;
 };
 
-export const getAxios = (url) => {
-  return instance.get(url);
+export const getAxios = (url, config) => {
+  return instance.get(url, config);
 };
 
 export const postAxios = (url, data) => {

--- a/src/pages/PracticePage.js
+++ b/src/pages/PracticePage.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
 
-import axios from 'axios';
 import { useSelector } from 'react-redux';
 import { useParams, Link } from 'react-router-dom';
+
+import { getAxios } from '../api';
 
 export default function PracticePage() {
   const { languages, types } = useParams();
@@ -11,13 +12,9 @@ export default function PracticePage() {
 
   useEffect(() => {
     const getParagraph = async () => {
-      const response = await axios.get(
+      const response = await getAxios(
         process.env.REACT_APP_SERVER_URL + `/languages/${languages}`,
-        {
-          params: {
-            type: types,
-          },
-        },
+        { params: { type: types } },
       );
 
       setParagraphs(response.data);


### PR DESCRIPTION
## 코드를 작성한 이유

- 기존에 작성한 axios instance 중 get함수는 url 정보만 받을 뿐 config 정보는 받지 못한다는 문제점이 있음

## 무엇이 변하였는가

- axios instance의 get 함수가 config 정보도 받을 수 있도록 리펙토링 함.
- 결과적으로 practicePage.js 파일에서 문제를 불러오는 부분의 기존 axios 함수를  axios instance로 변경함.

## 작성한 코드에 문제점이 존재하는가

- 없음

## 리뷰 중점사항 

- 늦은 시간에 리뷰해주셔서 감사합니다.
