### PR TITLE
feat: 단어 연습모드 구현 중(기본적인 타자 게임은 진행 가능), 정확도, WPM 로직추가

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import classNames from 'classnames';
+import classNames from 'classnames/bind';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/pages/PracticePage.js
+++ b/src/pages/PracticePage.js
@@ -5,6 +5,8 @@ import { useParams, Link } from 'react-router-dom';
 
 import { axiosGetRequest } from '../api';
 
+import WordPracticePage from './WordPracticePage';
+
 export default function PracticePage() {
   const { languages, types } = useParams();
   const isLoggedIn = useSelector((state) => state.user.isLoggedIn);
@@ -27,21 +29,11 @@ export default function PracticePage() {
     <div>
       {isLoggedIn ? (
         <div>
-          <h1>hello world</h1>
-          <div>
-            {problems?.map((list, index) => {
-              return (
-                <div key={index}>
-                  {list[languages]?.map((val, idx) => (
-                    <div style={{ whiteSpace: 'pre-wrap' }} key={idx}>
-                      {val}
-                      <div>-------------------------</div>
-                    </div>
-                  ))}
-                </div>
-              );
-            })}
-          </div>
+          <WordPracticePage
+            words={problems}
+            type={types}
+            languages={languages}
+          />
         </div>
       ) : (
         <div>

--- a/src/pages/WordPracticePage.js
+++ b/src/pages/WordPracticePage.js
@@ -1,0 +1,174 @@
+/* eslint-disable react/prop-types */
+import React, { useEffect, useRef, useState } from 'react';
+
+import classNames from 'classnames/bind';
+import { BiTimer } from 'react-icons/bi';
+
+import styles from './WordPracticePage.module.scss';
+
+const cx = classNames.bind(styles);
+const SECONDS = 30;
+
+export default function WordPracticePage({ words, languages }) {
+  const [countDown, setCountDown] = useState(SECONDS);
+  const [currInput, setCurrInput] = useState([]);
+  const [currWordIndex, setCurrWordIndex] = useState(0);
+  const [currCharIndex, setCurrCharIndex] = useState(-1);
+  const [currChar, setCurrChar] = useState('');
+  const [correct, setCorrect] = useState(0);
+  const [incorrect, setInCorrect] = useState(0);
+  const [status, setStatus] = useState('waiting');
+  const textInput = useRef(null);
+
+  const wordlist = words?.[0];
+  const selected = wordlist?.[languages];
+
+  function start() {
+    if (status === 'finished') {
+      setCurrWordIndex(0);
+      setCorrect(0);
+      setInCorrect(0);
+      setCurrCharIndex(-1);
+      setCurrChar('');
+    }
+
+    if (status !== 'started') {
+      setStatus('started');
+
+      let interval = setInterval(() => {
+        setCountDown((prevCountDown) => {
+          if (prevCountDown === 0) {
+            clearInterval(interval);
+            setStatus('finished');
+            setCurrInput('');
+            return SECONDS;
+          } else {
+            return prevCountDown - 1;
+          }
+        });
+      }, 1000);
+    }
+  }
+
+  function handleKeyDown({ keyCode, key }) {
+    if (keyCode === 32) {
+      checkMatch();
+      setCurrInput('');
+      setCurrWordIndex(currWordIndex + 1);
+      setCurrCharIndex(-1);
+    } else if (keyCode === 8) {
+      setCurrCharIndex(currCharIndex - 1);
+      setCurrChar('');
+    } else if (keyCode === 16) {
+      return;
+    } else {
+      setCurrCharIndex(currCharIndex + 1);
+      setCurrChar(key);
+    }
+  }
+
+  function checkMatch() {
+    const wordToCompare = selected[currWordIndex];
+    const doesItMatch = wordToCompare === currInput.trim();
+
+    if (doesItMatch) {
+      setCorrect(correct + 1);
+    } else {
+      setInCorrect(incorrect + 1);
+    }
+  }
+
+  function getCharClass(wordIdx, charIdx, char) {
+    if (
+      wordIdx === currWordIndex &&
+      charIdx === currCharIndex &&
+      currChar &&
+      status !== 'finished'
+    ) {
+      if (char === currChar) {
+        return cx('correct');
+      } else {
+        return cx('wrong');
+      }
+    } else if (
+      wordIdx === currWordIndex &&
+      currCharIndex >= selected[currWordIndex].length
+    ) {
+      return cx('wrong');
+    } else {
+      return '';
+    }
+  }
+
+  useEffect(() => {
+    if (status === 'started') {
+      textInput.current.focus();
+    }
+  }, [status]);
+
+  return (
+    <div>
+      <div className={cx('timer')}>
+        <div className={cx('timer__title')}>
+          Word Practice
+          <div className={cx('timer__logo')}>
+            <BiTimer /> {countDown}
+          </div>
+        </div>
+      </div>
+
+      <div className={cx()}>
+        <div className={cx('section', 'section__control')}>
+          <input
+            ref={textInput}
+            disabled={status !== 'started'}
+            className={cx('input')}
+            onKeyDown={handleKeyDown}
+            type="text"
+            value={currInput}
+            onChange={(e) => setCurrInput(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className={cx('section')}>
+        <button className={cx('button')} onClick={start}>
+          Start
+        </button>
+      </div>
+
+      {status === 'started' &&
+        selected.map((word, i) => (
+          <span key={i} className={cx('span')}>
+            <span>
+              {word.split('').map((char, index) => (
+                <span key={index}>
+                  <span className={getCharClass(i, index, char)} key={index}>
+                    {char}
+                  </span>
+                </span>
+              ))}
+            </span>
+            <span> </span>
+          </span>
+        ))}
+
+      {status === 'finished' && (
+        <div className={cx('section')}>
+          <div className="columns">
+            <div className="">
+              <p className="">Words Per Minute :</p>
+              <p className="">{correct}</p>
+            </div>
+            <div className="">
+              <div className="">Accuracy :</div>
+              <p className="">
+                {Math.round((correct / (correct + incorrect)) * 100)} %
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/WordPracticePage.module.scss
+++ b/src/pages/WordPracticePage.module.scss
@@ -1,0 +1,38 @@
+.section {
+  padding: 3rem 1.5rem;
+}
+
+.input {
+  width: 100%;
+  height: 100%;
+  font-size: 50px;
+}
+
+.span {
+  font-size: 25px;
+  background-color: white;
+}
+
+.correct {
+  color: blue;
+}
+
+.wrong {
+  color: red;
+}
+
+.timer {
+  border: 1px solid black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px;
+  &__logo {
+    font-size: 30px;
+    font-weight: bold;
+  }
+  &__title {
+    font-size: 50px;
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
## 코드를 작성한 이유

- 핵심 기능 중 하나인 단어 연습모드를 구현 중입니다.
- 현재 기본적인 게임은 가능합니다(DEMO)

## 무엇이 변하였는가

- 단어연습모드가 추가되었습니다.

## 작성한 코드에 문제점이 존재하는가

- 상태가 너무 많긴한 점이 좀 걸리지만, 해당 상태를 다른곳에서 사용할 일은 없을 것 같아서 일단 생각 중입니다. 
- practice page에서 각 언어별 -> 연습모드 별 나눠주는 곳에 로직을 하나 더 추가해야할 것 같습니다.

## 리뷰 중점사항 

- 중복되는 코드라던지, 코드스타일, 리팩토링 할 것들 한번씩 봐주시면 감사하겠습니다.

