### PR TITLE
ParagraghPracticePage 생성 및 paragraph 타자연습기능 구현, paragraph 정보 요청과 상태 관리를 위한 redux 및 redux-saga 코드 추가

### DIFF
--- a/src/features/problemSaga.js
+++ b/src/features/problemSaga.js
@@ -3,6 +3,8 @@ import { put, takeLatest, call, delay, take } from 'redux-saga/effects';
 import { axiosGetRequest } from '../api';
 
 import {
+  getParagraphList,
+  getParagraphListSuccess,
   getSentenceList,
   getSentenceListSucces,
   getWordList,
@@ -41,10 +43,30 @@ function* getSentenceListSaga(action) {
   yield put(getSentenceListSucces(result.data[0][language]));
 }
 
+function* getParagraphListSaga(action) {
+  const language = action.payload.languages;
+  const practiceType = action.payload.types;
+
+  const result = yield call(() => {
+    return axiosGetRequest(
+      process.env.REACT_APP_SERVER_URL + '/languages/' + language,
+      {
+        params: { type: practiceType },
+      },
+    );
+  });
+
+  yield put(getParagraphListSuccess(result.data));
+}
+
 export function* watchGetWordList() {
   yield takeLatest(getWordList, getWordListSaga);
 }
 
 export function* watchGetSentenceList() {
   yield takeLatest(getSentenceList, getSentenceListSaga);
+}
+
+export function* watchGetParagraphList() {
+  yield takeLatest(getParagraphList, getParagraphListSaga);
 }

--- a/src/features/problemSlice.js
+++ b/src/features/problemSlice.js
@@ -7,6 +7,9 @@ export const problemsSlice = createSlice({
     isLoading: false,
     wordList: [],
     sentenceList: [],
+    paragraphCList: [],
+    paragraphJavaScriptList: [],
+    paragraphPythonList: [],
   },
 
   reducers: {
@@ -24,6 +27,15 @@ export const problemsSlice = createSlice({
       state.isLoading = false;
       state.sentenceList = [...action.payload];
     },
+    getParagraphList: (state) => {
+      state.isLoading = true;
+    },
+    getParagraphListSuccess: (state, action) => {
+      state.isLoading = false;
+      state.paragraphCList = [...action.payload[0]['C']];
+      state.paragraphJavaScriptList = [...action.payload[1]['JavaScript']];
+      state.paragraphPythonList = [...action.payload[2]['Python']];
+    },
   },
 });
 
@@ -32,6 +44,8 @@ export const {
   getWordListSuccess,
   getSentenceList,
   getSentenceListSucces,
+  getParagraphList,
+  getParagraphListSuccess,
 } = problemsSlice.actions;
 
 export default problemsSlice.reducer;

--- a/src/pages/ParagraphPracticePage.js
+++ b/src/pages/ParagraphPracticePage.js
@@ -1,0 +1,207 @@
+import React, { useEffect, useState, useRef } from 'react';
+
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+
+import Button from '../components/Button';
+import Keyboard from '../components/Keyboard';
+import Modal from '../components/Modal';
+import ModalPortal from '../ModalPortal';
+import getCharacterClass from '../utils/getCharacterClass';
+
+import styles from './WordPracticePage.module.scss';
+
+export default function ParagraphPracticePage({ languages }) {
+  const navigate = useNavigate();
+
+  const paragraphList = useSelector((state) => {
+    if (languages === 'C') return state.problem.paragraphCList;
+    if (languages === 'JavaScript') {
+      return state.problem.paragraphJavaScriptList;
+    }
+    if (languages === 'Python') return state.problem.paragraphPythonList;
+  });
+  const name = useSelector((state) => state.user.name);
+
+  const [question, setQuestion] = useState('');
+  const [currentInput, setCurrentInput] = useState('');
+
+  const [correctWordCount, setCorrectWordCount] = useState(0);
+  const [incorrectWordCount, setIncorrectWordCount] = useState(0);
+
+  const [second, setSecond] = useState(0);
+  const [typingSpeed, setTypingSpeed] = useState(0);
+
+  const [isStarted, setIsStarted] = useState(false);
+  const [isEnded, setIsEnded] = useState(false);
+  const [isShowingModal, setIsShowingModal] = useState(false);
+
+  const inputElement = useRef(null);
+  const interval = useRef(null);
+  const lapsedTime = useRef(0);
+
+  const keyBoardButton = {
+    tab: 9,
+  };
+
+  useEffect(() => {
+    nextQuestion();
+  }, [paragraphList]);
+
+  useEffect(() => {
+    return () => {
+      clearInterval(interval.current);
+    };
+  }, []);
+
+  const nextQuestion = () => {
+    const randomIndex = Math.floor(Math.random() * 10) % paragraphList.length;
+    setQuestion(paragraphList[randomIndex]);
+
+    setCurrentInput('');
+
+    setSecond(0);
+    setTypingSpeed(0);
+
+    setCorrectWordCount(0);
+    setIncorrectWordCount(0);
+
+    setIsStarted(false);
+    setIsEnded(false);
+
+    lapsedTime.current = 0;
+  };
+
+  const startTimer = () => {
+    if (!isStarted) {
+      setIsStarted(true);
+
+      interval.current = setInterval(() => {
+        lapsedTime.current += 1;
+        setSecond((previousSecond) => previousSecond + 1);
+      }, 1000);
+    }
+  };
+
+  const finishPractice = (userInput) => {
+    if (userInput.length === question.length) {
+      clearInterval(interval.current);
+
+      setIsEnded(true);
+      setIsShowingModal(true);
+    }
+  };
+
+  const checkCorrectWords = (currentInput) => {
+    const text = question?.replace(' ', '');
+
+    const correctText = currentInput
+      .replace(' ', '')
+      .split('')
+      .filter((value, index) => value === text[index]).length;
+
+    const incorrectText = currentInput
+      .replace(' ', '')
+      .split('')
+      .filter((value, index) => value !== text[index]).length;
+
+    setCorrectWordCount(correctText);
+    setIncorrectWordCount(incorrectText);
+  };
+
+  const handleChange = (e) => {
+    startTimer();
+
+    finishPractice(e.target.value);
+
+    setCurrentInput(e.target.value);
+    checkCorrectWords(e.target.value);
+
+    setTypingSpeed(correctWordCount / (second / 60));
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.keyCode === keyBoardButton.tab) {
+      e.preventDefault();
+
+      setCurrentInput(e.target.value + '\t');
+    }
+  };
+
+  const handleButtonClick = () => {
+    setIsShowingModal(false);
+
+    navigate('/');
+  };
+
+  return (
+    <div>
+      <div>
+        {question?.split('').map((character, index) => (
+          <span
+            key={index}
+            className={getCharacterClass(currentInput, index, character)}
+            style={{ whiteSpace: 'pre-wrap' }}
+          >
+            {character}
+          </span>
+        ))}
+      </div>
+      <div>
+        <textarea
+          ref={inputElement}
+          value={currentInput}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          readOnly={isEnded}
+          style={{ width: '100%', height: '100px' }}
+        />
+      </div>
+      <div>
+        <div>
+          {correctWordCount !== 0 && second !== 0 && (
+            <div>{Math.round(typingSpeed)} wpm</div>
+          )}
+        </div>
+        <p>맞은 횟수{correctWordCount}</p>
+        <p>틀린 횟수{incorrectWordCount}</p>
+        {correctWordCount !== 0 && incorrectWordCount !== 0 && (
+          <p>
+            Accuracy:
+            {Math.round(
+              (correctWordCount / (correctWordCount + incorrectWordCount)) *
+                100,
+            )}
+          </p>
+        )}
+      </div>
+
+      <Keyboard />
+
+      {isShowingModal && (
+        <ModalPortal>
+          <Modal
+            message={
+              <div>
+                <h1>문장 연습 결과</h1>
+                <p>{name} 님의 연습 결과</p>
+                <p>
+                  정확도:{' '}
+                  {Math.round(
+                    (correctWordCount /
+                      (correctWordCount + incorrectWordCount)) *
+                      100,
+                  )}
+                  %
+                </p>
+                <p>평균 타자속도: {Math.floor(typingSpeed)} 타 / 분</p>
+                <Button onClick={handleButtonClick}>홈으로 이동하기</Button>
+              </div>
+            }
+            onCloseModal={setIsShowingModal}
+          />
+        </ModalPortal>
+      )}
+    </div>
+  );
+}

--- a/src/pages/PracticePage.js
+++ b/src/pages/PracticePage.js
@@ -3,8 +3,13 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams, Link } from 'react-router-dom';
 
-import { getSentenceList, getWordList } from '../features/problemSlice';
+import {
+  getParagraphList,
+  getSentenceList,
+  getWordList,
+} from '../features/problemSlice';
 
+import ParagraphPracticePage from './ParagraphPracticePage';
 import SentencePracticePage from './SentencePracticePage';
 import WordPracticePage from './WordPracticePage';
 
@@ -20,17 +25,20 @@ export default function PracticePage() {
     isLoggedIn &&
       types === 'sentence' &&
       dispatch(getSentenceList({ languages, types }));
+    isLoggedIn &&
+      types === 'paragraph' &&
+      dispatch(getParagraphList({ languages, types }));
   }, [types, languages, isLoggedIn]);
 
   return (
     <div>
       {isLoggedIn ? (
         <div>
-          {types === 'word' ? (
-            <WordPracticePage />
-          ) : (
-            <SentencePracticePage selectedLanguage={languages} />
-          )}
+          {(types === 'word' && <WordPracticePage />) ||
+            (types === 'sentence' && <SentencePracticePage />) ||
+            (types === 'paragraph' && (
+              <ParagraphPracticePage languages={languages} />
+            ))}
         </div>
       ) : (
         <div>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ import logger from 'redux-logger';
 import { all, fork } from 'redux-saga/effects';
 
 import {
+  watchGetParagraphList,
   watchGetSentenceList,
   watchGetWordList,
 } from '../features/problemSaga';
@@ -30,6 +31,7 @@ function* rootSaga() {
     fork(watchRefresh),
     fork(watchGetWordList),
     fork(watchGetSentenceList),
+    fork(watchGetParagraphList),
     fork(watchupdateUserRecord),
     fork(watchLoadUserRecord),
   ]);


### PR DESCRIPTION
## 코드를 작성한 이유

- redux-saga를 통해 paragraph 타자 연습 페이지로 들어갔을 경우, db에서 정보를 가져와 redux에서 상태관리를 하기위해 코드를 작성하였습니다.
- 가져온 paragraph 정보를 redux에 저장시켜두기 위해 redux에 코드를 추가하였습니다.
- ParagraphPracticePage에 들어갈 수 있게  PracticePage 컴포넌트에 조건문을 이용한 코드를 추가하였습니다.
- ParagraphPracticePage 컴포넌트에서 긴 글 타자 연습 기능을 구현하였습니다.

## 무엇이 변하였는가

- 긴글 타자 연습 기능이 추가 되었습니다.
- redux 및 redux-saga에 위에 설명드린 부분을 위한 코드를 추가하였습니다.

## 작성한 코드에 문제점이 존재하는가

- 일단 제가 생각한 대로 기능이 작동되서 아직은 문제점이 없지만 계속해서 코드를 살펴보고 기능 구현을 해보면서 문제가 있는지 파악할 예정입니다.

## 리뷰 중점사항 

- 긴글 타자 연습을 단어 및 짧은 글 타자 연습 기능을 이용해서 구현하려고 하였지만, 단어와 짧은 글은 글의 길이가 짧기 때문에 단어 하나하나를 비교해서 correct 및 incorrect를 판단하고 속도를 구함에 있어서 문제가 없지만 긴글은 그런 코드로 시도를 해보니 문제가 많았습니다.
- 그래서 현재 push한 코드에서 보듯이 단어 하나하나를 filter를 통해 문제와 같은지 틀린지를 비교하여 correct와 incorrect의 개수를 세고, 하나하나 칠때마다 속도도 반영되므로 제가 원하는 긴 글 연습 기능에 맞다고 생각하지만, 문제점이 있다면 리뷰 부탁드립니다.
- 속도계산은 짧은 글과 다른데 제가 조사한 바로는 아래와 같습니다.
`// wpm = 총 (정확하게 누룬)누룬 키수 / 분 = 정확하게 입력한 총 타자 키수 / (1 / 60)분
  // 분 => 1s = (1 / 60)분`
