### PR TITLE
Feat/score 기능 추가 및 과거 기록 평균 보여주는 부분 구현, 짧은 글 연습 점수 부여 기능 구현

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -19,7 +19,7 @@ body {
   display: flex;
   overflow-y: auto;
   &__sidebar {
-    flex: 0 0 240px;
+    flex: 0 0 280px;
     background-color: #5c49a7;
     height: 100vh;
   }

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -18,25 +18,27 @@ const cx = classNames.bind(styles);
 export default function Menu() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+
   const isLoggedIn = useSelector((state) => state.user.isLoggedIn);
   const name = useSelector((state) => state.user.name);
   const isPracticing = useSelector((state) => state.user.isPracticing);
   const selectedLanguage = useSelector((state) => state.user.selectedLanguage);
+
   const [isShowing, setIsShowing] = useState(false);
   const items = [
     {
       path: `/practice/${selectedLanguage}/word`,
-      text: '낱말 연습',
+      text: `${selectedLanguage} 낱말 연습`,
       logo: <FaKeyboard />,
     },
     {
       path: `/practice/${selectedLanguage}/sentence`,
-      text: '짧은 글 연습',
+      text: `${selectedLanguage} 짧은 글 연습`,
       logo: <FaKeyboard />,
     },
     {
       path: `/practice/${selectedLanguage}/paragraph`,
-      text: '긴 글 연습',
+      text: `${selectedLanguage} 긴 글 연습`,
       logo: <FaKeyboard />,
     },
   ];
@@ -65,9 +67,6 @@ export default function Menu() {
         <div className={cx('userInfo')}>
           <ul className={cx('userInfo__List')}>
             <li className={cx('userInfo__name')}>{name}님 환영합니다</li>
-            <li className={cx('userInfo__lang')}>
-              선택한 언어: {selectedLanguage}
-            </li>
           </ul>
           {isPracticing ? (
             <div className={cx('menu')}>

--- a/src/features/userSaga.js
+++ b/src/features/userSaga.js
@@ -152,6 +152,7 @@ function* updateUserRecordSaga(action) {
       accuracy: action.payload.accuracy,
       time: action.payload.time,
       type: action.payload.type,
+      score: action.payload.score,
     },
   );
 }

--- a/src/features/userSlice.js
+++ b/src/features/userSlice.js
@@ -90,6 +90,7 @@ export const userSlice = createSlice({
       state.history = action.payload;
     },
     updateUserRecord: (state, action) => {
+      state.hiscore += action.payload.score;
       state.history = [
         ...state.history,
         {

--- a/src/pages/SentencePracticePage.js
+++ b/src/pages/SentencePracticePage.js
@@ -45,6 +45,8 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
   const [sentenceAccracy, setSentenceAccracy] = useState(0);
   const [sentenceAccracySum, setSentenceAccracySum] = useState(0);
 
+  const [score, setScore] = useState(0);
+
   const inputElement = useRef(null);
   const lapsedTime = useRef(0);
   const correctkeyDownCount = useRef(0);
@@ -72,6 +74,7 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
           accuracy: Math.floor((sentenceAccracySum / numberProblems) * 100),
           typingSpeed: Math.floor(typingSpeedSum / numberProblems),
           time: dayjs().format('YYYY.MM.DDTHH:mm'),
+          score,
         }),
       );
       setIsShowing(true);
@@ -110,6 +113,10 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
 
     setCurrentInput('');
     setCurrentInputIndex(0);
+
+    if (sentenceAccracy === 1) {
+      setScore((prev) => prev + 3);
+    }
 
     setSentenceAccracySum((prev) => prev + sentenceAccracy);
     setTypingSpeedSum((prev) => prev + typingSpeed);
@@ -216,7 +223,7 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
         %
       </p>
       <p>진행도: {Math.floor((attemptCount / numberProblems) * 100)} %</p>
-
+      <p>획득점수: {score} 점</p>
       <Keyboard />
 
       {isShowing && (
@@ -231,6 +238,7 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
                   {Math.floor((sentenceAccracySum / numberProblems) * 100)} %
                 </p>
                 <p>타수: {Math.floor(typingSpeedSum / numberProblems)} 타</p>
+                <p>획득점수: {score} 점</p>
                 <Button onClick={handleButtonClick}>홈으로 이동하기</Button>
               </div>
             }

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -83,19 +83,31 @@ export default function UserPage() {
               <span className={cx('userpage__data__logo')}>
                 <FaCaretRight />
               </span>
-              <span className={cx('userpage__data__title')}>
-                {selectedLanguageSetting} 점수 :
+              <span className={cx('userpage__data__title')}> 총 점수:</span>
+              <span className={cx('userpage__data__content')}>
+                {' '}
+                {hiscore} 점
               </span>
-              <span className={cx('userpage__data__content')}> {hiscore}</span>
             </li>
             <li className={cx('userpage__data__item')}>
               <span className={cx('userpage__data__logo')}>
                 <FaCaretRight />
               </span>
               <span className={cx('userpage__data__title')}>
-                {selectedLanguageSetting} 평균 타수 :
+                {selectedLanguageSetting} 평균 타수:
               </span>
-              <span className={cx('userpage__data__content')}> 타</span>
+              <span className={cx('userpage__data__content')}>
+                {' '}
+                {Math.floor(
+                  history.reduce((accumulator, current, index, array) => {
+                    if (index === array.length - 1) {
+                      return (accumulator + current.typingSpeed) / array.length;
+                    }
+                    return accumulator + current.typingSpeed;
+                  }, 0),
+                )}
+                타
+              </span>
             </li>
             <li className={cx('userpage__data__item')}>
               <span className={cx('userpage__data__logo')}>
@@ -104,7 +116,18 @@ export default function UserPage() {
               <span className={cx('userpage__data__title')}>
                 {selectedLanguageSetting} 평균 정확도 :
               </span>
-              <span className={cx('userpage__data__content')}> %</span>
+              <span className={cx('userpage__data__content')}>
+                {' '}
+                {Math.floor(
+                  history.reduce((accumulator, current, index, array) => {
+                    if (index === array.length - 1) {
+                      return (accumulator + current.accuracy) / array.length;
+                    }
+                    return accumulator + current.accuracy;
+                  }, 0),
+                )}
+                %
+              </span>
             </li>
           </ul>
           {/* 환경 설정 칸 */}


### PR DESCRIPTION
## 코드를 작성한 이유

- 유저 별 점수를 보여주는 기능을 추가할 필요성이 있었음
- 각 언어별 연습 기록들을 이용하여, 평균 타수 및 평균 정확도를 표현해줄 필요성이 있었음
- 메뉴 바에 어떤 언어 연습으로 바로 넘어갈 수 있는지 언어적으로 정확하게 표기해줄 필요성이 있었음
- 짧은 글 연습 중 정확도를 100% 달성한 문장에 대해 점수를 획득하고 이를 서버로 넘겨줄 필요성이 있었음

## 무엇이 변하였는가

- 짧은 글 연습을 수행하며, 만약 정확도 100%를 달성하였다면, 3점을 부여한 뒤, 연습이 끝나면 획득한 총 점수를 redux에 전달하도록 하였음
- 마이 페이지에 들어가면, 그동안 획득한 총 점수의 합을 보여주도록 하였음.
- 지난 날의 연습 기록을 통해 평균 타수와 정확도가 어느 정도인지 평균을 보여주는 기능을 추가하였음.
- 메뉴바의 css를 수정하였고, 어떤 언어 연습으로 바로 넘어갈 수 있는지 표시하였음  

## 작성한 코드에 문제점이 존재하는가

- 없음

## 리뷰 중점사항 

- 없음
