### PR TITLE
feat: 긴글로직 추가, 키보드 차단 케이스 & 상수추가, 기록 저장 시 시간 형식 변경, 유저페이지 기록 최신순 정렬, 5개만 보이도록 css 설정 및 기타 CSS추가

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -11,7 +11,7 @@
 
 body {
   font-family: 'Poppins', 'sans-serif';
-  // overflow: hidden;
+  overflow: auto;
   background: rgb(240, 244, 248);
 }
 
@@ -38,13 +38,13 @@ body {
 }
 
 .correct {
-  // background-color: blue;
-  // color: white;
   color: #1fbd83;
 }
 
 .wrong {
-  // background-color: red;
-  // color: white;
   color: hotpink;
+}
+
+.currentSpan {
+  border-bottom: 5px solid lightseagreen;
 }

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import './Button.scss';
 
-// eslint-disable-next-line react/prop-types
 export default function Button({ children, onClick }) {
   return (
     <div>

--- a/src/components/Keyboard.js
+++ b/src/components/Keyboard.js
@@ -4,6 +4,7 @@ import classNames from 'classnames/bind';
 import { useSelector } from 'react-redux';
 
 import keyboard from '../audios/keyboard.mp3';
+import { keyboardButton } from '../utils/constants';
 
 import styles from './Keyboard.module.scss';
 
@@ -23,22 +24,26 @@ export default function Keyboard({ isGameEnd }) {
 
     if (
       keyCode === null ||
-      keyCode === 27 ||
-      keyCode === 229 ||
-      keyCode === 37 ||
-      keyCode === 38 ||
-      keyCode === 39 ||
-      keyCode === 40 ||
-      keyCode === 96 ||
-      keyCode === 97 ||
-      keyCode === 98 ||
-      keyCode === 99 ||
-      keyCode === 100 ||
-      keyCode === 101 ||
-      keyCode === 102 ||
-      keyCode === 103 ||
-      keyCode === 104 ||
-      keyCode === 105
+      keyCode === keyboardButton.esc ||
+      keyCode === keyboardButton.koreanLanguage ||
+      keyCode === keyboardButton.arrowLeft ||
+      keyCode === keyboardButton.arrowUp ||
+      keyCode === keyboardButton.arrowRight ||
+      keyCode === keyboardButton.arrowDown ||
+      keyCode === keyboardButton.numPad0 ||
+      keyCode === keyboardButton.numPad1 ||
+      keyCode === keyboardButton.numPad2 ||
+      keyCode === keyboardButton.numPad3 ||
+      keyCode === keyboardButton.numPad4 ||
+      keyCode === keyboardButton.numPad5 ||
+      keyCode === keyboardButton.numPad6 ||
+      keyCode === keyboardButton.numPad7 ||
+      keyCode === keyboardButton.numPad8 ||
+      keyCode === keyboardButton.numPad9 ||
+      keyCode === keyboardButton.numPadStar ||
+      keyCode === keyboardButton.numPadPlus ||
+      keyCode === keyboardButton.numPadBlack ||
+      keyCode === keyboardButton.numPadMinus
     )
       return;
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import './Modal.scss';
 
-// eslint-disable-next-line react/prop-types
 export default function Modal({ message, onCloseModal }) {
   return (
     <div className="modal__background" onClick={() => onCloseModal(false)}>

--- a/src/components/Modal.scss
+++ b/src/components/Modal.scss
@@ -36,3 +36,20 @@
     border: white;
   }
 }
+
+.practice_result {
+  position: relative;
+  bottom: 30px;
+  &__content {
+    background: white;
+    color: black;
+    width: 60%;
+    margin: 0 auto;
+    margin-top: 10px;
+    border-radius: 15px;
+    padding: 10px;
+  }
+  &__button {
+    display: inline-block;
+  }
+}

--- a/src/pages/ParagraphPracticePage.js
+++ b/src/pages/ParagraphPracticePage.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react';
 
+import classNames from 'classnames/bind';
 import dayjs from 'dayjs';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
@@ -15,10 +16,11 @@ import {
 } from '../utils/constants';
 import getCharacterClass from '../utils/getCharacterClass';
 
+import styles from './ParagraphPracticePage.module.scss';
+const cx = classNames.bind(styles);
 export default function ParagraphPracticePage({ selectedLanguage, type }) {
   const navigate = useNavigate();
   const dispatch = useDispatch();
-
   const uid = useSelector((state) => state.user.uid);
   const numberProblems = useSelector((state) => state.user.numberProblems);
   const paragraphList = useSelector((state) => {
@@ -29,45 +31,34 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
     if (selectedLanguage === 'Python') return state.problem.paragraphPythonList;
   });
   const name = useSelector((state) => state.user.name);
-
   const [question, setQuestion] = useState('');
   const [currentInput, setCurrentInput] = useState('');
-
   const [attemptCount, setAttemptCount] = useState(0);
-
   const [paragraphAccuracy, setParagraphAccuracy] = useState(0);
   const [paragraphAccuracySum, setParagraphAccuracySum] = useState(0);
-
   const [typingSpeed, setTypingSpeed] = useState(0);
   const [typingSpeedSum, setTypingSpeedSum] = useState(0);
-
   const [correctWordCount, setCorrectWordCount] = useState(0);
   const [incorrectWordCount, setIncorrectWordCount] = useState(0);
-
   const [score, setScore] = useState(0);
   const [currentInputIndex, setCurrentInputIndex] = useState(0);
   const [previousInputIndex, setPreviousInputIndex] = useState(0);
-
   const [isStarted, setIsStarted] = useState(false);
   const [isEnded, setIsEnded] = useState(false);
   const [isShowingModal, setIsShowingModal] = useState(false);
-
   const inputElement = useRef(null);
   const interval = useRef(null);
   const lapsedTime = useRef(0);
   const correctkeyDownCount = useRef(0);
-
   useEffect(() => {
     paragraphList?.length && nextQuestion();
     inputElement.current.focus();
   }, [paragraphList]);
-
   useEffect(() => {
     return () => {
       clearInterval(interval.current);
     };
   }, []);
-
   useMemo(() => {
     if (attemptCount === numberProblems) {
       dispatch(
@@ -81,12 +72,10 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
           score,
         }),
       );
-
       setIsShowingModal(true);
       setIsEnded(true);
     }
   }, [attemptCount]);
-
   useMemo(() => {
     if (currentInput) {
       setParagraphAccuracy(
@@ -94,53 +83,38 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
       );
     }
   }, [currentInput]);
-
   const increaseAttemptCount = () => {
     setAttemptCount((prev) => prev + 1);
   };
-
   const nextQuestion = () => {
     const randomIndex = Math.floor(Math.random() * 1000) % paragraphList.length;
     setQuestion(paragraphList[randomIndex]);
-
     setCurrentInput('');
-
     setCorrectWordCount(0);
     setIncorrectWordCount(0);
-
     setParagraphAccuracySum((prev) => prev + paragraphAccuracy);
     setTypingSpeedSum((prev) => prev + typingSpeed);
-
     setParagraphAccuracy(0);
     setTypingSpeed(0);
-
     setCurrentInputIndex(0);
     setPreviousInputIndex(0);
-
     setIsStarted(false);
     setIsEnded(false);
-
     lapsedTime.current = 0;
     correctkeyDownCount.current = 0;
   };
-
   const startTimer = () => {
     if (!isStarted) {
       setIsStarted(true);
-
       interval.current = setInterval(() => {
         lapsedTime.current += 1;
-
         let currentSpeed =
           (correctkeyDownCount.current / lapsedTime.current) * 600;
-
         currentSpeed = currentSpeed > 0 ? currentSpeed : 0;
-
         setTypingSpeed(currentSpeed);
       }, 100);
     }
   };
-
   const finishPractice = (userInput) => {
     if (userInput.length === question.length) {
       if (
@@ -148,70 +122,53 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
         question.slice(previousInputIndex, currentInputIndex)
       ) {
         setScore((prev) => prev + 3);
-
         clearInterval(interval.current);
-
         increaseAttemptCount();
         nextQuestion();
       } else {
         clearInterval(interval.current);
-
         increaseAttemptCount();
         nextQuestion();
       }
     }
   };
-
   const checkCorrectWords = (currentInput) => {
     const text = question?.replace(' ', '');
-
     const correctText = currentInput
       .replace(' ', '')
       .split('')
       .filter((value, index) => value === text[index]).length;
-
     const incorrectText = currentInput
       .replace(' ', '')
       .split('')
       .filter((value, index) => value !== text[index]).length;
-
     correctkeyDownCount.current = correctText;
-
     setCorrectWordCount(correctText);
     setIncorrectWordCount(incorrectText);
   };
-
   const handleChange = (e) => {
     if (e.target.value === 'ㅁ' || e.target.value === 'ㅊ') {
       return;
     }
-
     startTimer();
-
     setCurrentInput(e.target.value);
     checkCorrectWords(e.target.value);
-
     finishPractice(e.target.value);
   };
-
   const handleKeyDown = (e) => {
     if (e.keyCode === keyboardButton.koreanLanguage) {
       e.preventDefault();
-
       return;
     } else if (prohibitedParagraphKeyCodeList.includes(e.keyCode)) {
       e.preventDefault();
-
       return;
     } else if (e.keyCode === keyboardButton.tab) {
       e.preventDefault();
-
       setCurrentInput(e.target.value + '  ');
       setCurrentInputIndex(currentInputIndex + 2);
     } else if (e.keyCode === keyboardButton.enter) {
       if (currentInputIndex === 0) {
         e.preventDefault();
-
         return;
       } else if (
         currentInput.slice(previousInputIndex, currentInputIndex) ===
@@ -228,7 +185,6 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
       if (previousInputIndex === 0) {
         if (currentInputIndex === 0) {
           e.preventDefault();
-
           return;
         } else {
           setCurrentInputIndex(currentInputIndex - 1);
@@ -236,45 +192,39 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
       } else {
         if (previousInputIndex + 1 === currentInputIndex) {
           e.preventDefault();
-
           return;
         } else {
           setCurrentInputIndex(currentInputIndex - 1);
         }
       }
     } else if (e.keyCode === keyboardButton.shift) {
-      e.preventDefault();
-
       return;
     } else {
       setCurrentInputIndex(currentInputIndex + 1);
     }
   };
-
   const handleButtonClick = () => {
     setIsShowingModal(false);
     navigate('/');
   };
-
   return (
-    <div>
-      <div>
+    <div className={cx('container')}>
+      <div className={cx('container__title')}>
         <h3>긴 글 연습</h3>
       </div>
-      <div>
+      <div className={cx('question')}>
         {question?.split('').map((character, index) => (
           <span
             key={index}
             className={getCharacterClass(currentInput, index, character)}
-            style={{ whiteSpace: 'pre-wrap', fontSize: '20px' }}
           >
             {character}
           </span>
         ))}
       </div>
-
-      <div>
+      <div className={cx('section')}>
         <textarea
+          className={cx('section__input')}
           ref={inputElement}
           value={currentInput}
           onChange={handleChange}
@@ -282,16 +232,21 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
           readOnly={isEnded}
         />
       </div>
-
-      <div>
+      <div className={cx('result')}>
         <p>
-          타수:{' '}
+          <span className={cx('result__dataname')}>타수: </span>
           {lapsedTime.current !== 0 ? <>{Math.round(typingSpeed)} 타/분</> : 0}
         </p>
-        <p>맞은 횟수{correctWordCount}</p>
-        <p>틀린 횟수{incorrectWordCount}</p>
         <p>
-          현재 정확도:{' '}
+          <span className={cx('result__dataname')}>맞은 횟수: </span>
+          {correctWordCount}
+        </p>
+        <p>
+          <span className={cx('result__dataname')}>틀린 횟수: </span>
+          {incorrectWordCount}
+        </p>
+        <p>
+          <span className={cx('result__dataname')}>현재 정확도: </span>
           {correctWordCount !== 0 &&
             Math.round(
               (correctWordCount / (correctWordCount + incorrectWordCount)) *
@@ -299,15 +254,19 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
             )}
         </p>
         <p>
-          누적 정확도:{' '}
+          <span className={cx('result__dataname')}>누적 정확도: </span>
           {attemptCount ? Math.floor(paragraphAccuracySum / attemptCount) : 0} %
         </p>
-        <p>진행도: {Math.floor((attemptCount / numberProblems) * 100)} %</p>
-        <p>획득점수: {score} 점</p>
+        <p>
+          <span className={cx('result__dataname')}>진행도: </span>
+          {Math.floor((attemptCount / numberProblems) * 100)} %
+        </p>
+        <p>
+          <span className={cx('result__dataname')}>획득점수: </span>
+          {score} 점
+        </p>
       </div>
-
       <Keyboard />
-
       {isShowingModal && (
         <ModalPortal>
           <Modal

--- a/src/pages/ParagraphPracticePage.module.scss
+++ b/src/pages/ParagraphPracticePage.module.scss
@@ -1,0 +1,51 @@
+.container {
+  padding: 50px;
+  border: 2px solid black;
+  border-radius: 15px;
+
+  &__title {
+    font-size: 30px;
+  }
+}
+
+.question {
+  padding: 20px;
+  margin: 0px 20px 30px 20px;
+  border: 2px solid black;
+  border-radius: 10px;
+  background-color: white;
+  font-size: 20px;
+  box-shadow: 3px 3px rgba(126, 130, 143, 0.8);
+  white-space: pre-wrap;
+
+  span {
+    padding: 1px;
+  }
+}
+
+.section {
+  margin: 0px 500px;
+
+  &__input {
+    width: 100%;
+    border: 0;
+    border-radius: 10px;
+    background-color: rgb(255, 255, 255);
+    outline: none;
+  }
+}
+
+.result {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  padding: 20px;
+  margin: 20px;
+  font-size: 20px;
+
+  &__dataname {
+    margin: 20px;
+    font-size: 25px;
+    font-weight: bold;
+  }
+}

--- a/src/pages/SentencePracticePage.js
+++ b/src/pages/SentencePracticePage.js
@@ -73,7 +73,7 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
           language: selectedLanguage,
           accuracy: Math.floor((sentenceAccracySum / numberProblems) * 100),
           typingSpeed: Math.floor(typingSpeedSum / numberProblems),
-          time: dayjs().format('YYYY.MM.DDTHH:mm'),
+          time: dayjs().format('YYYY-MM-DDTHH:mm'),
           score,
         }),
       );

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -267,36 +267,39 @@ export default function UserPage() {
             </div>
 
             <div className={cx('history')}>
-              {history?.map((data, index) => {
-                let className;
-                {
-                  className =
-                    typeToKoreanName[data.type] === '짧은 글'
-                      ? 'sentence'
-                      : 'pragraph';
-                }
+              {history
+                ?.slice()
+                .sort((a, b) => new Date(b.time) - new Date(a.time))
+                .map((data, index) => {
+                  let className;
+                  {
+                    className =
+                      typeToKoreanName[data.type] === '짧은 글'
+                        ? 'sentence'
+                        : 'pragraph';
+                  }
 
-                return (
-                  <div key={index} className={cx('history__content')}>
-                    <span className={cx('history__content', `${className}`)}>
-                      {typeToKoreanName[data.type]}
-                    </span>
-                    <span className={cx('history__data')}>
-                      {data.time?.replace('T', ' ')} <FaRegHandPointRight />
-                    </span>
-                    <span className={cx('history__data')}>
-                      <span className={cx('history__data__title')}>
-                        타속 : {data.typingSpeed}
+                  return (
+                    <div key={index} className={cx('history__content')}>
+                      <span className={cx('history__content', `${className}`)}>
+                        {typeToKoreanName[data.type]}
                       </span>
-                    </span>
-                    <span className={cx('history__data')}>
-                      <span className={cx('history__data__title')}>
-                        정확도 : {data.accuracy}%
+                      <span className={cx('history__data')}>
+                        {data.time?.replace('T', ' ')} <FaRegHandPointRight />
                       </span>
-                    </span>
-                  </div>
-                );
-              })}
+                      <span className={cx('history__data')}>
+                        <span className={cx('history__data__title')}>
+                          타속 : {data.typingSpeed}
+                        </span>
+                      </span>
+                      <span className={cx('history__data')}>
+                        <span className={cx('history__data__title')}>
+                          정확도 : {data.accuracy}%
+                        </span>
+                      </span>
+                    </div>
+                  );
+                })}
             </div>
           </div>
 

--- a/src/pages/UserPage.module.scss
+++ b/src/pages/UserPage.module.scss
@@ -83,7 +83,8 @@
   border: 0;
   border-radius: 15px;
   background-color: white;
-
+  height: 215px;
+  overflow: auto;
   &__content {
     padding: 7px;
   }

--- a/src/pages/WordPracticePage.js
+++ b/src/pages/WordPracticePage.js
@@ -47,6 +47,18 @@ export default function WordPracticePage() {
   const lapsedTime = useRef(0);
   const interval = useRef(null);
 
+  let currentQuestionId = document.getElementById(questionIndex);
+
+  useEffect(() => {
+    currentQuestionId = document.getElementById(questionIndex);
+
+    currentQuestionId?.classList.add(cx('currentSpan'));
+
+    return () => {
+      currentQuestionId?.classList.remove(cx('currentSpan'));
+    };
+  }, [questionIndex]);
+
   useEffect(() => {
     nextQuestion();
     inputElement.current.focus();
@@ -75,6 +87,7 @@ export default function WordPracticePage() {
   const nextQuestion = () => {
     const randomIndex = Math.floor(Math.random() * 1000) % wordList.length;
     setQuestion(wordList[randomIndex]);
+    setQuestionIndex(0);
     setQuestionLength(wordList[randomIndex]?.length);
     setCurrentInput('');
   };
@@ -123,10 +136,8 @@ export default function WordPracticePage() {
       setCurrentInputIndex((prev) => prev + 1);
     } else if (event.keyCode === keyboardButton.backspace) {
       currentQuestionId.classList.remove(cx('currentSpan'));
-      // currentQuestionId.classList.add(cx('currentSpan'));
 
       if (questionIndex > 0) {
-        // currentQuestionId.classList.add(cx('currentSpan'));
         setQuestionIndex((prev) => prev - 1);
         setCurrentInputIndex((prev) => prev - 1);
       }
@@ -135,6 +146,7 @@ export default function WordPracticePage() {
     } else {
       setQuestionIndex((prev) => prev + 1);
       setCurrentInputIndex((prev) => prev + 1);
+      currentQuestionId?.classList.add('current');
     }
   };
 
@@ -151,17 +163,6 @@ export default function WordPracticePage() {
     dispatch(finishPractice());
     navigate('/');
   };
-  const currentQuestionId = document.getElementById(questionIndex);
-  console.log('현재 단어 인덱스', questionIndex);
-  console.log('캐릭터인덱스::', currentQuestionId);
-
-  useEffect(() => {
-    currentQuestionId?.classList.add(cx('currentSpan'));
-  }, [questionIndex]);
-
-  console.log(questionIndex);
-  // const currentCh_span = document.getElementById(`${this.state.currentIndex}`);
-  // currentCh_span.classList.add('current');
 
   return (
     <div className={cx('container')}>
@@ -225,18 +226,23 @@ export default function WordPracticePage() {
         <ModalPortal>
           <Modal
             message={
-              <div>
-                <h1>낱말 연습 결과</h1>
-                <p>{name} 님의 기록은</p>
-                <p>
-                  정확도: {Math.round((correctCount / numberProblems) * 100)} %
-                </p>
-                <p>오타수: {incorrectCount} 개</p>
-                <p>
-                  소요시간: {Math.floor(lapsedTime.current / 60)} 분{' '}
-                  {lapsedTime.current % 60} 초
-                </p>
-                <Button onClick={handleButtonClick}>홈으로 이동하기</Button>
+              <div className={cx('practice_result')}>
+                <h1 className={cx('practice_result__title')}>낱말 연습 결과</h1>
+                <div className={cx('practice_result__content')}>
+                  <p>{name} 님의 기록은</p>
+                  <p>
+                    정확도 : {Math.round((correctCount / numberProblems) * 100)}{' '}
+                    %
+                  </p>
+                  <p>오타수 : {incorrectCount} 개</p>
+                  <p>
+                    소요시간 : {Math.floor(lapsedTime.current / 60)} 분{' '}
+                    {lapsedTime.current % 60} 초
+                  </p>
+                </div>
+                <div className={cx('practice_result__button')}>
+                  <Button onClick={handleButtonClick}>홈으로 이동하기</Button>
+                </div>
               </div>
             }
             onCloseModal={setIsShowing}

--- a/src/pages/WordPracticePage.module.scss
+++ b/src/pages/WordPracticePage.module.scss
@@ -74,7 +74,3 @@
     font-size: 20px;
   }
 }
-
-.currentSpan {
-  border-bottom: 5px solid lightseagreen;
-}

--- a/src/utils/getCharacterClass.js
+++ b/src/utils/getCharacterClass.js
@@ -1,8 +1,12 @@
 export default function getCharacterClass(currentInput, index, character) {
+  const currentQuestionId = document.getElementById(index);
+
   if (index < currentInput.split('').length) {
     if (character === currentInput.split('')[index]) {
+      currentQuestionId?.classList.remove('current');
       return 'correct';
     } else {
+      currentQuestionId?.classList.remove('current');
       return 'wrong';
     }
   }


### PR DESCRIPTION
## 코드를 작성한 이유 & 무엇이 변하였는가

- Keyboard.js에 예외케이스 추가, 상수로 만들어논 케이스 추가 및 활용
- 기록 저장 후, 유저페이지에서 최신순으로 불러올 때 sort메서드를 써보니 되지않았습니다. => `new Date()` 미사용과 날짜 형식 문제였습니다.
- 유저페이지 기록 부분이 나중에 많아지면 전체페이지가 너무 길어질 상황을 대비하여 CSS div 속성들을 이용하여 5개씩만 보여주고, 스크롤로 그 다음 기록들을 볼 수 있게 변경하였습니다.
- 이전에 발생하던 단어연습모드에서 커서위치 로직을 변경하였습니다.

## 작성한 코드에 문제점이 존재하는가

- 긴 글 연습 점수 로직을 추가하는 중입니다.
- 긴 글 연습 Saga, slice 쪽 구조에 문제가 있습니다.

## 리뷰 중점사항 

- 전체적으로 고친 파일이 많습니다. 다같이 천천히 보시고 피드백 하면서 고쳐나갑시다 화이팅입니다!
