### PR TITLE
fix: 윈도우 운영체제에서 한글 입력이 막히지 않는 버그 해결

### DIFF
--- a/src/pages/ParagraphPracticePage.js
+++ b/src/pages/ParagraphPracticePage.js
@@ -183,49 +183,49 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
     setIncorrectWordCount(incorrectText);
   };
 
-  const handleChange = (e) => {
-    if (checkKoreanInput(e.target.value)) {
+  const handleChange = (event) => {
+    if (checkKoreanInput(event.target.value)) {
       alert('영문키로 바꾸세요!');
 
       return;
     }
 
     startTimer();
-    setCurrentInput(e.target.value);
-    checkCorrectWords(e.target.value);
-    finishPractice(e.target.value);
+    setCurrentInput(event.target.value);
+    checkCorrectWords(event.target.value);
+    finishPractice(event.target.value);
   };
 
-  const handleKeyDown = (e) => {
-    if (checkKoreanInput(e.key)) {
+  const handleKeyDown = (event) => {
+    if (checkKoreanInput(event.key) || event.key === 'Process') {
       return;
-    } else if (prohibitedParagraphKeyCodeList.includes(e.keyCode)) {
-      e.preventDefault();
+    } else if (prohibitedParagraphKeyCodeList.includes(event.keyCode)) {
+      event.preventDefault();
 
       return;
-    } else if (e.keyCode === keyboardButton.tab) {
-      e.preventDefault();
+    } else if (event.keyCode === keyboardButton.tab) {
+      event.preventDefault();
 
-      setCurrentInput(e.target.value + '  ');
+      setCurrentInput(event.target.value + '  ');
       setCurrentInputIndex(currentInputIndex + 2);
-    } else if (e.keyCode === keyboardButton.enter) {
+    } else if (event.keyCode === keyboardButton.enter) {
       if (currentInputIndex === 0) {
-        e.preventDefault();
+        event.preventDefault();
 
         return;
       } else {
         setCurrentInputIndex(currentInputIndex + 1);
         currentQuestionId?.classList.add('current');
       }
-    } else if (e.keyCode === keyboardButton.backspace) {
+    } else if (event.keyCode === keyboardButton.backspace) {
       if (currentInputIndex === 0) {
-        e.preventDefault();
+        event.preventDefault();
         return;
       } else {
         setCurrentInputIndex(currentInputIndex - 1);
         currentQuestionId.classList.remove(cx('currentSpan'));
       }
-    } else if (e.keyCode === keyboardButton.shift) {
+    } else if (event.keyCode === keyboardButton.shift) {
       return;
     } else {
       setCurrentInputIndex(currentInputIndex + 1);

--- a/src/pages/SentencePracticePage.js
+++ b/src/pages/SentencePracticePage.js
@@ -156,7 +156,7 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
   };
 
   const handleKeyDown = (event) => {
-    if (checkKoreanInput(event.key)) {
+    if (checkKoreanInput(event.key) || event.key === 'Process') {
       return;
     }
 

--- a/src/pages/WordPracticePage.js
+++ b/src/pages/WordPracticePage.js
@@ -119,7 +119,7 @@ export default function WordPracticePage() {
   };
 
   const handleKeyDown = (event) => {
-    if (checkKoreanInput(event.key)) {
+    if (checkKoreanInput(event.key) || event.key === 'Process') {
       return;
     }
 
@@ -155,16 +155,16 @@ export default function WordPracticePage() {
     }
   };
 
-  const handleChange = (e) => {
+  const handleChange = (event) => {
     if (checkKoreanInput(event.target.value)) {
       alert('영문키로 바꾸세요!');
       return;
     }
 
-    setCurrentInput(e.target.value);
+    setCurrentInput(event.target.value);
 
     if (currentInputIndex >= questionLength) {
-      checkAnswer(e.target.value);
+      checkAnswer(event.target.value);
     }
   };
 


### PR DESCRIPTION
## 코드를 작성한 이유

- 윈도우 환경에서는 한글 입력이 막히지 않는 문제점을 발견해서 이를 해결함

## 무엇이 변하였는가

- 맥 OS 환경에서는 한글 key Down 이벤트가 발생할 때 event.key 값에 한글 글자가 출력되지만 윈도우 환경에서는 한글 입력이 발생할 때 event.key 값에 한글 글자가 아닌 'Process'라는 값이 출력되었다. 
- 이런 까닭에 한글 입력을 감지하는 checkKoreanInput 함수가 제대로 작동하지 않아, 이를 수정하였다. 

## 작성한 코드에 문제점이 존재하는가

- 수정한 버전이 다시 또 맥 OS에서 제대로 작동하는지 확인이 필요할 것 같다.

## 리뷰 중점사항 

- 없음
