### PR TITLE
feat: 유저가 색약 모드를 선택할 수 있도록 유저 페이지 라디오 버튼 추가 및 redux 및 saga 함수 구현

### DIFF
--- a/src/features/userSaga.js
+++ b/src/features/userSaga.js
@@ -86,6 +86,7 @@ function* anonymousLoginSaga() {
     selectedLanguage: 'JavaScript',
     hiscore: 0,
     numberProblems: 10,
+    isColorWeaknessUser: false,
   };
 
   yield put(loginSuccess(setting));
@@ -106,6 +107,7 @@ function* changeSettingSaga(action) {
       selectedLanguage: action.payload.selectedLanguageSetting,
       soundEffects: action.payload.soundEffectsSetting,
       numberProblems: action.payload.numberProblemsSetting,
+      isColorWeaknessUser: action.payload.colorWeaknessSetting,
     },
   );
 }

--- a/src/features/userSlice.js
+++ b/src/features/userSlice.js
@@ -10,6 +10,7 @@ export const userSlice = createSlice({
     isLoggedIn: false,
     isPracticing: false,
     isAnonymousUser: false,
+    isColorWeaknessUser: false,
     name: null,
     email: null,
     uid: null,
@@ -38,6 +39,7 @@ export const userSlice = createSlice({
       state.selectedLanguage = action.payload?.selectedLanguage;
       state.hiscore = action.payload?.hiscore;
       state.numberProblems = action.payload?.numberProblems;
+      state.isColorWeaknessUser = action.payload?.isColorWeaknessUser;
     },
     logout: (state) => {
       state.isUserDataLoading = true;
@@ -52,6 +54,7 @@ export const userSlice = createSlice({
       state.soundEffects = null;
       state.selectedLanguage = null;
       state.numberProblems = null;
+      state.isColorWeaknessUser = null;
     },
     loginFailure: (state) => {
       state.isUserDataLoading = false;
@@ -61,6 +64,7 @@ export const userSlice = createSlice({
       state.soundEffects = action.payload?.soundEffectsSetting;
       state.selectedLanguage = action.payload?.selectedLanguageSetting;
       state.numberProblems = action.payload?.numberProblemsSetting;
+      state.isColorWeaknessUser = action.payload?.colorWeaknessSetting;
     },
     loadUserDbData: (state) => {
       state.isUserDataLoading = true;
@@ -75,6 +79,7 @@ export const userSlice = createSlice({
       state.selectedLanguage = action.payload?.selectedLanguage;
       state.hiscore = action.payload?.hiscore;
       state.numberProblems = action.payload?.numberProblems;
+      state.isColorWeaknessUser = action.payload?.isColorWeaknessUser;
     },
     startPractice: (state) => {
       state.isPracticing = true;

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -33,16 +33,21 @@ export default function UserPage() {
   const isLoggedIn = useSelector((state) => state.user.isLoggedIn);
   const numberProblems = useSelector((state) => state.user.numberProblems);
   const history = useSelector((state) => state.user.history);
+  const isColorWeaknessUser = useSelector(
+    (state) => state.user.isColorWeaknessUser,
+  );
 
   const [selectedLanguageSetting, setSelectedLanguageSetting] = useState(null);
   const [soundEffectsSetting, setSoundEffectsSetting] = useState(null);
   const [numberProblemsSetting, setNumberProblemsSetting] = useState(null);
+  const [colorWeaknessSetting, setColorWeaknessSetting] = useState(null);
 
   useEffect(() => {
     setSoundEffectsSetting(soundEffects);
     setSelectedLanguageSetting(selectedLanguage);
     setNumberProblemsSetting(numberProblems);
-  }, [soundEffects, selectedLanguage, numberProblems]);
+    setColorWeaknessSetting(isColorWeaknessUser);
+  }, [soundEffects, selectedLanguage, numberProblems, isColorWeaknessUser]);
 
   useMemo(() => {
     selectedLanguageSetting &&
@@ -61,6 +66,10 @@ export default function UserPage() {
     setNumberProblemsSetting(Number(e.target.value));
   };
 
+  const handleColorWeaknessRadioButtonClick = (e) => {
+    setColorWeaknessSetting(e.target.value === 'true');
+  };
+
   const handleSettingSaveButtonClick = async () => {
     dispatch(
       changeSetting({
@@ -68,6 +77,7 @@ export default function UserPage() {
         selectedLanguageSetting,
         soundEffectsSetting,
         numberProblemsSetting,
+        colorWeaknessSetting,
       }),
     );
   };
@@ -219,7 +229,6 @@ export default function UserPage() {
                 </span>
                 <span>문제 개수 설정</span>
               </div>
-
               <label>
                 <input
                   type="radio"
@@ -251,6 +260,33 @@ export default function UserPage() {
                 40개
               </label>
             </li>
+
+            <li className={cx('userpage__setting__item')}>
+              <div className={cx('userpage__setting__title')}>
+                <span>색약 모드 설정</span>
+              </div>
+              <label>
+                <input
+                  type="radio"
+                  name="colorWeakness"
+                  value="true"
+                  onChange={handleColorWeaknessRadioButtonClick}
+                  checked={colorWeaknessSetting === true}
+                />{' '}
+                켜기
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="colorWeakness"
+                  value="false"
+                  onChange={handleColorWeaknessRadioButtonClick}
+                  checked={colorWeaknessSetting === false}
+                />{' '}
+                끄기
+              </label>
+            </li>
+
             <li className={cx('userpage__setting__item')}>
               <button onClick={handleSettingSaveButtonClick}>
                 <div className={cx('save_btn')}>설정 저장하기</div>


### PR DESCRIPTION
## 코드를 작성한 이유

- 배포를 진행하고 나서, 다른 동료들에게 베타 테스트를 부탁했습니다. 
- 그 중 적록색약이 있는 한 동료로부터, 연습 오답여부에 따른 색 구분이 잘 가지 않는다는 의견을 들었습니다.
- 따라서 좀 더 좋은 사용자 경험을 제공하기 위해, 적록색약 여부를 선택하는 기능을 만들었고,  
이에 따라 오답여부에 따른 색 표현이 다르게 이루어지도록 할 필요성이 있었습니다. 

## 무엇이 변하였는가

- 유저 페이지에서 색약 모드를 선택할 수 있도록 라디오 버튼을 구현하였습니다. 
- 또 저장버튼을 눌렀을 때 색약 모드 선택 여부가 redux 상태에 저장될 수 있도록 하였고, 
백엔드에도 patch 요청이 가도록 액션함수를 수정하였습니다.
- 이제 이 상태값을 바탕으로 실제 CSS가 변경되도록 구현할 예정입니다. 

## 작성한 코드에 문제점이 존재하는가

- 없습니다.

## 리뷰 중점사항 

- 없습니다. 
