### PR TITLE
Fix/연습모드 상태 여부와 관련한 버그 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -6,7 +6,7 @@ import { FaKeyboard, FaHome } from 'react-icons/fa';
 import { useSelector, useDispatch } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
 
-import { startPractice, finishPractice } from '../features/userSlice';
+import { setPracticeMode, unsetPracticeMode } from '../features/userSlice';
 import ModalPortal from '../ModalPortal';
 
 import Button from './Button';
@@ -44,12 +44,12 @@ export default function Menu() {
   ];
 
   const handleStartPracticeButtonClick = () => {
-    dispatch(startPractice());
+    dispatch(setPracticeMode());
   };
 
   const handleGoBackHomeButtonClick = () => {
     setIsShowing(false);
-    dispatch(finishPractice());
+    dispatch(unsetPracticeMode());
     navigate('/');
   };
 
@@ -108,7 +108,6 @@ export default function Menu() {
               <div className={cx('gameover')}>
                 <p>
                   정말로 연습을 종료하시겠습니까? <br />
-                  진행상황은 저장되지 않습니다.
                 </p>
                 <div className={cx('gameover__btn')}>
                   <Button onClick={handleGoBackHomeButtonClick}>Yes</Button>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,15 +1,24 @@
 import React from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import './Modal.scss';
 
-export default function Modal({ message, onCloseModal }) {
+export default function Modal({ message, onCloseModal, redirectLink }) {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    onCloseModal(false);
+
+    if (redirectLink) {
+      navigate(redirectLink);
+    }
+  };
+
   return (
-    <div className="modal__background" onClick={() => onCloseModal(false)}>
-      <div className="modal__box" onClick={(e) => e.stopPropagation()}>
-        <button
-          className="modal__closeModalBtn"
-          onClick={() => onCloseModal(false)}
-        >
+    <div className="modal__background" onClick={handleClick}>
+      <div className="modal__box" onClick={(event) => event.stopPropagation()}>
+        <button className="modal__closeModalBtn" onClick={handleClick}>
           X
         </button>
         <div className="modal__content">{message}</div>

--- a/src/components/Topbar.js
+++ b/src/components/Topbar.js
@@ -1,19 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import classNames from 'classnames/bind';
 import { FaFileCode } from 'react-icons/fa';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
-import { login, logout, anonymousLogin } from '../features/userSlice';
+import {
+  login,
+  logout,
+  anonymousLogin,
+  unsetPracticeMode,
+} from '../features/userSlice';
+import ModalPortal from '../ModalPortal';
 
 import Button from './Button';
+import Modal from './Modal';
 import Spinner from './Spinner';
 import styles from './Topbar.module.scss';
 
 const topbar = classNames.bind(styles);
 
 export default function Topbar() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
   const userId = useSelector((state) => state.user.uid);
   const isLoggedIn = useSelector((state) => state.user.isLoggedIn);
   const isPracticing = useSelector((state) => state.user.isPracticing);
@@ -23,8 +33,7 @@ export default function Topbar() {
   const isRefreshing = useSelector((state) => state.user.isRefreshing);
   const isAnonymousUser = useSelector((state) => state.user.isAnonymousUser);
 
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
+  const [isShowingModal, setIsShowingModal] = useState(false);
 
   const handleLoginButtonClick = () => {
     dispatch(login());
@@ -37,18 +46,34 @@ export default function Topbar() {
   const handleLogoutButtonClick = () => {
     dispatch(logout());
   };
+
+  const handleLogoClick = () => {
+    if (isPracticing) {
+      setIsShowingModal(true);
+    } else {
+      navigate('/');
+    }
+  };
+
   const handleMyPageButtonClick = () => {
     navigate(`/users/${userId}`);
+  };
+
+  const handleGoBackHomeButtonClick = () => {
+    setIsShowingModal(false);
+    dispatch(unsetPracticeMode());
+    navigate('/');
+  };
+
+  const handleResumePracticeButtonClick = () => {
+    setIsShowingModal(false);
   };
 
   return (
     <div className={topbar('topbar')}>
       <div className={topbar('topbar__wrapper')}>
         <div className={topbar('topbar__left')}>
-          <span
-            className={topbar('topbar__logo')}
-            onClick={() => navigate('/')}
-          >
+          <span className={topbar('topbar__logo')} onClick={handleLogoClick}>
             <FaFileCode /> Code Typing Practice
           </span>
         </div>
@@ -72,6 +97,24 @@ export default function Topbar() {
           )}
         </div>
       </div>
+      {isShowingModal && (
+        <ModalPortal>
+          <Modal
+            message={
+              <div>
+                <p>
+                  정말로 연습을 종료하시겠습니까? <br />
+                </p>
+                <div>
+                  <Button onClick={handleGoBackHomeButtonClick}>Yes</Button>
+                  <Button onClick={handleResumePracticeButtonClick}>No</Button>
+                </div>
+              </div>
+            }
+            onCloseModal={setIsShowingModal}
+          ></Modal>
+        </ModalPortal>
+      )}
     </div>
   );
 }

--- a/src/features/userSlice.js
+++ b/src/features/userSlice.js
@@ -81,10 +81,10 @@ export const userSlice = createSlice({
       state.numberProblems = action.payload?.numberProblems;
       state.isColorWeaknessUser = action.payload?.isColorWeaknessUser;
     },
-    startPractice: (state) => {
+    setPracticeMode: (state) => {
       state.isPracticing = true;
     },
-    finishPractice: (state) => {
+    unsetPracticeMode: (state) => {
       state.isPracticing = false;
     },
     startRefresh: (state) => {
@@ -125,8 +125,8 @@ export const {
   changeSetting,
   loadUserDbData,
   loadUserDbDataSuccess,
-  startPractice,
-  finishPractice,
+  setPracticeMode,
+  unsetPracticeMode,
   startRefresh,
   finishRefresh,
   loadUserRecord,

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import classNames from 'classnames/bind';
 import { useDispatch } from 'react-redux';
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 
 import Button from '../components/Button';
 import Modal from '../components/Modal';
-import { startPractice } from '../features/userSlice';
+import { unsetPracticeMode, setPracticeMode } from '../features/userSlice';
 import ModalPortal from '../ModalPortal';
 
 import styles from './Home.module.scss';
@@ -15,26 +15,31 @@ const cx = classNames.bind(styles);
 export default function Home() {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+
   const [isShowing, setIsShowing] = useState(false);
   const [language, setLanguage] = useState('');
 
-  const handleModalOpen = (lang, e) => {
+  useEffect(() => {
+    dispatch(unsetPracticeMode());
+  }, []);
+
+  const handleModalOpen = (lang, event) => {
     setLanguage(lang);
     setIsShowing(true);
   };
 
   const handleWordButtnoCLick = () => {
-    dispatch(startPractice());
+    dispatch(setPracticeMode());
     navigate(`/practice/${language}/word`);
   };
 
   const handleSentenceButtnoCLick = () => {
-    dispatch(startPractice());
+    dispatch(setPracticeMode());
     navigate(`/practice/${language}/sentence`);
   };
 
   const handleParagraphButtnoCLick = () => {
-    dispatch(startPractice());
+    dispatch(setPracticeMode());
     navigate(`/practice/${language}/paragraph`);
   };
 

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -50,8 +50,8 @@ export default function Home() {
       </header>
       <section>
         <article
-          onClick={(e) => {
-            handleModalOpen('C', e);
+          onClick={(event) => {
+            handleModalOpen('C', event);
           }}
         >
           <div className={cx('home__content')}>
@@ -70,8 +70,8 @@ export default function Home() {
           </div>
         </article>
         <article
-          onClick={(e) => {
-            handleModalOpen('Python', e);
+          onClick={(event) => {
+            handleModalOpen('Python', event);
           }}
         >
           <div className={cx('home__content')}>
@@ -91,8 +91,8 @@ export default function Home() {
           </div>
         </article>
         <article
-          onClick={(e) => {
-            handleModalOpen('JavaScript', e);
+          onClick={(event) => {
+            handleModalOpen('JavaScript', event);
           }}
         >
           <div className={cx('home__content')}>

--- a/src/pages/ParagraphPracticePage.js
+++ b/src/pages/ParagraphPracticePage.js
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import Button from '../components/Button';
 import Keyboard from '../components/Keyboard';
 import Modal from '../components/Modal';
-import { updateUserRecord } from '../features/userSlice';
+import { unsetPracticeMode, updateUserRecord } from '../features/userSlice';
 import ModalPortal from '../ModalPortal';
 import checkKoreanInput from '../utils/checkKoreanInput';
 import {
@@ -235,7 +235,6 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
 
   const handleButtonClick = () => {
     setIsShowingModal(false);
-    dispatch(finishPractice());
     navigate('/');
   };
 
@@ -321,6 +320,7 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
               </div>
             }
             onCloseModal={setIsShowingModal}
+            redirectLink="/"
           />
         </ModalPortal>
       )}

--- a/src/pages/SentencePracticePage.js
+++ b/src/pages/SentencePracticePage.js
@@ -10,7 +10,7 @@ import wrong from '../audios/wrong.mp3';
 import Button from '../components/Button';
 import Keyboard from '../components/Keyboard';
 import Modal from '../components/Modal';
-import { finishPractice, updateUserRecord } from '../features/userSlice';
+import { unsetPracticeMode, updateUserRecord } from '../features/userSlice';
 import ModalPortal from '../ModalPortal';
 import checkKoreanInput from '../utils/checkKoreanInput';
 import { keyboardButton, prohibitedKeyCodeList } from '../utils/constants';
@@ -220,7 +220,6 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
 
   const handleButtonClick = () => {
     setIsShowingModal(false);
-    dispatch(finishPractice());
     navigate('/');
   };
 
@@ -315,7 +314,7 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
                     타수 : {Math.floor(typingSpeedSum / numberProblems)} 타
                   </p>
                   <p className={cx('practice_result__content__item')}>
-                    <p>획득점수 : {score} 점</p>
+                    획득점수 : {score} 점
                   </p>
                 </div>
                 <div className={cx('practice_result__button')}>
@@ -324,6 +323,7 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
               </div>
             }
             onCloseModal={setIsShowingModal}
+            redirectLink="/"
           />
         </ModalPortal>
       )}

--- a/src/pages/WordPracticePage.js
+++ b/src/pages/WordPracticePage.js
@@ -9,7 +9,7 @@ import wrong from '../audios/wrong.mp3';
 import Button from '../components/Button';
 import Keyboard from '../components/Keyboard';
 import Modal from '../components/Modal';
-import { finishPractice } from '../features/userSlice';
+import { unsetPracticeMode } from '../features/userSlice';
 import ModalPortal from '../ModalPortal';
 import checkKoreanInput from '../utils/checkKoreanInput';
 import { keyboardButton, prohibitedKeyCodeList } from '../utils/constants';
@@ -170,7 +170,6 @@ export default function WordPracticePage() {
 
   const handleButtonClick = () => {
     setIsShowingModal(false);
-    dispatch(finishPractice());
     navigate('/');
   };
 
@@ -260,6 +259,7 @@ export default function WordPracticePage() {
               </div>
             }
             onCloseModal={setIsShowingModal}
+            redirectLink="/"
           />
         </ModalPortal>
       )}


### PR DESCRIPTION
## 코드를 작성한 이유

- 기존 코드에서는 연습이 끝났음에도 불구하고 상단 바 및 메뉴 바가 제대로 갱신되지 않는 문제점이 존재하였습니다. 
(이는 메인 화면으로 복귀했음에도, redux 상태는 계속 연습 모드로 유지되는 버그가 있었기 때문입니다)
- 연습 화면으로 넘어간 경우 뒤로가기 및 로고를 눌렀을 때 정말 나갈 것인지 묻는 모달이 뜨며, 그 외에 상태에서는 모달이 뜨지 않도록 구현할 필요성이 있었습니다. 
- 그 외에 자잘한 버그를 수정할 필요성이 있었습니다.

## 무엇이 변하였는가

- 메인 화면으로 복귀한 경우(랜더링 된 경우) 연습 모드를 해제하는 액션함수를 발생시켜 버그를 해결하였습니다.
- 만약 redux 상태가 연습 모드로 되어있는 경우 로고 버튼을 눌렀을 때 정말 나갈 것인지 물으며, 그 외의 경우에는 로고버튼을 눌렀을 때 바로 메인 화면으로 복귀하도록 경우를 나누어 구현하였습니다. 
- p 태그의 중첩으로 인해 발생하는 오류를 고쳤습니다.
- git이 배포가 완료된 파일 폴더를 추적하지 않도록 변경하였습니다.
- 연습모드 여부를 디스패치해주는 액션함수명을 변경하였습니다. 

## 작성한 코드에 문제점이 존재하는가

- 혹시 모를 버그가 있을 가능성이 있는 것 같습니다.

## 리뷰 중점사항 

- 문제점이 보이신다면 알려주세요.
