### PR TITLE
feat: 색약모드 기능 추가, 커서위치보이는 로직 변경

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -3,7 +3,6 @@
   padding: 0;
   box-sizing: border-box;
   list-style: none;
-  line-height: 1.5;
   user-select: none;
 }
 
@@ -40,4 +39,17 @@ body {
 
 .currentSpan {
   border-bottom: 5px solid lightseagreen;
+}
+
+.correct_colorWeakness {
+  color: blue;
+}
+
+.wrong_colorWeakness {
+  color: #ebeb24;
+  border-bottom: 5px solid #ebeb24;
+}
+
+.currentSpan_colorWeakness {
+  border-bottom: 5px solid blue;
 }

--- a/src/components/Topbar.js
+++ b/src/components/Topbar.js
@@ -18,7 +18,7 @@ import Modal from './Modal';
 import Spinner from './Spinner';
 import styles from './Topbar.module.scss';
 
-const topbar = classNames.bind(styles);
+const cx = classNames.bind(styles);
 
 export default function Topbar() {
   const navigate = useNavigate();
@@ -70,25 +70,25 @@ export default function Topbar() {
   };
 
   return (
-    <div className={topbar('topbar')}>
-      <div className={topbar('topbar__wrapper')}>
-        <div className={topbar('topbar__left')}>
-          <span className={topbar('topbar__logo')} onClick={handleLogoClick}>
+    <div className={cx('topbar')}>
+      <div className={cx('topbar__wrapper')}>
+        <div className={cx('topbar__left')}>
+          <span className={cx('topbar__logo')} onClick={handleLogoClick}>
             <FaFileCode /> Code Typing Practice
           </span>
         </div>
-        <div className={topbar('topbar__right')}>
+        <div className={cx('topbar__right')}>
           {isUserDataLoading || isRefreshing ? (
             <Spinner />
           ) : isLoggedIn ? (
-            <div className={topbar('topbar__right')}>
+            <div className={cx('topbar__right')}>
               {!isPracticing && !isAnonymousUser && (
                 <Button onClick={handleMyPageButtonClick}>My Page</Button>
               )}
               <Button onClick={handleLogoutButtonClick}>Sign Out</Button>
             </div>
           ) : (
-            <div className={topbar('topbar__right')}>
+            <div className={cx('topbar__right')}>
               <Button onClick={handleLoginButtonClick}>Google SignIn</Button>
               <Button onClick={handleAnonymousLoginButtonClick}>
                 Guest SignIn
@@ -105,7 +105,7 @@ export default function Topbar() {
                 <p>
                   정말로 연습을 종료하시겠습니까? <br />
                 </p>
-                <div>
+                <div className={cx('gameover__btn')}>
                   <Button onClick={handleGoBackHomeButtonClick}>Yes</Button>
                   <Button onClick={handleResumePracticeButtonClick}>No</Button>
                 </div>

--- a/src/components/Topbar.module.scss
+++ b/src/components/Topbar.module.scss
@@ -17,3 +17,11 @@
     display: flex;
   }
 }
+
+.gameover {
+  &__btn {
+    padding-top: 20px;
+    justify-content: center;
+    display: flex;
+  }
+}

--- a/src/pages/ParagraphPracticePage.js
+++ b/src/pages/ParagraphPracticePage.js
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useRef, useMemo } from 'react';
+import React, {
+  useEffect,
+  useState,
+  useRef,
+  useMemo,
+  useLayoutEffect,
+} from 'react';
 
 import classNames from 'classnames/bind';
 import dayjs from 'dayjs';
@@ -8,7 +14,7 @@ import { useNavigate } from 'react-router-dom';
 import Button from '../components/Button';
 import Keyboard from '../components/Keyboard';
 import Modal from '../components/Modal';
-import { unsetPracticeMode, updateUserRecord } from '../features/userSlice';
+import { updateUserRecord } from '../features/userSlice';
 import ModalPortal from '../ModalPortal';
 import checkKoreanInput from '../utils/checkKoreanInput';
 import {
@@ -30,6 +36,9 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
   const numberProblems = useSelector((state) => state.user.numberProblems);
   const paragraphList = useSelector((state) => state.problem.paragraphList);
   const isAnonymousUser = useSelector((state) => state.user.isAnonymousUser);
+  const isColorWeaknessUser = useSelector(
+    (state) => state.user.isColorWeaknessUser,
+  );
 
   const [question, setQuestion] = useState('');
 
@@ -57,17 +66,20 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
   const lapsedTime = useRef(0);
   const correctkeyDownCount = useRef(0);
 
+  const currentSpanTag = isColorWeaknessUser
+    ? 'currentSpan_colorWeakness'
+    : 'currentSpan';
+
   let currentQuestionId = document.getElementById(currentInputIndex);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     currentQuestionId = document.getElementById(currentInputIndex);
 
-    currentQuestionId?.classList.add(cx('currentSpan'));
-
+    currentQuestionId?.classList.add(cx(currentSpanTag));
     return () => {
-      currentQuestionId?.classList.remove(cx('currentSpan'));
+      currentQuestionId?.classList.remove(cx(currentSpanTag));
     };
-  }, [currentInputIndex, currentQuestionId]);
+  });
 
   useEffect(() => {
     paragraphList?.length && nextQuestion();
@@ -248,7 +260,12 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
           <span
             key={index}
             id={index}
-            className={getCharacterClass(currentInput, index, character)}
+            className={getCharacterClass(
+              currentInput,
+              index,
+              character,
+              isColorWeaknessUser,
+            )}
           >
             {character}
           </span>

--- a/src/pages/ParagraphPracticePage.module.scss
+++ b/src/pages/ParagraphPracticePage.module.scss
@@ -7,7 +7,7 @@ $border-color: 2px solid black;
 
   &__title {
     padding: 0.25em 0.5em;
-    border-left: solid 10px blue;
+    border-left: solid 10px #843253;
     font-size: 20px;
   }
 }
@@ -21,6 +21,7 @@ $border-color: 2px solid black;
   font-size: 20px;
   box-shadow: 3px 3px rgba(126, 130, 143, 0.8);
   white-space: pre-wrap;
+  font-family: 'Noto Serif', serif;
 
   span {
     padding: 1px;
@@ -36,6 +37,7 @@ $border-color: 2px solid black;
     border-radius: 10px;
     background-color: rgb(255, 255, 255);
     font-size: 30px;
+    font-family: 'Noto Serif', serif;
     outline: none;
   }
 }

--- a/src/pages/SentencePracticePage.js
+++ b/src/pages/SentencePracticePage.js
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import classNames from 'classnames/bind';
 import dayjs from 'dayjs';
@@ -10,7 +16,7 @@ import wrong from '../audios/wrong.mp3';
 import Button from '../components/Button';
 import Keyboard from '../components/Keyboard';
 import Modal from '../components/Modal';
-import { unsetPracticeMode, updateUserRecord } from '../features/userSlice';
+import { updateUserRecord } from '../features/userSlice';
 import ModalPortal from '../ModalPortal';
 import checkKoreanInput from '../utils/checkKoreanInput';
 import { keyboardButton, prohibitedKeyCodeList } from '../utils/constants';
@@ -30,6 +36,9 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
   const isTurnedOn = useSelector((state) => state.user.soundEffects);
   const sentenceList = useSelector((state) => state.problem.sentenceList);
   const isAnonymousUser = useSelector((state) => state.user.isAnonymousUser);
+  const isColorWeaknessUser = useSelector(
+    (state) => state.user.isColorWeaknessUser,
+  );
 
   const [question, setQuestion] = useState('');
   const [questionLength, setQuestionLength] = useState(0);
@@ -58,17 +67,20 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
   const backSpaceKeyDownCount = useRef(0);
   const interval = useRef(null);
 
+  const currentSpanTag = isColorWeaknessUser
+    ? 'currentSpan_colorWeakness'
+    : 'currentSpan';
+
   let currentQuestionId = document.getElementById(questionIndex);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     currentQuestionId = document.getElementById(questionIndex);
 
-    currentQuestionId?.classList.add(cx('currentSpan'));
-
+    currentQuestionId?.classList.add(cx(currentSpanTag));
     return () => {
-      currentQuestionId?.classList.remove(cx('currentSpan'));
+      currentQuestionId?.classList.remove(cx(currentSpanTag));
     };
-  }, [questionIndex]);
+  });
 
   useEffect(() => {
     sentenceList.length && nextQuestion();
@@ -269,7 +281,12 @@ export default function SentencePracticePage({ selectedLanguage, type }) {
             <span
               key={index}
               id={index}
-              className={getCharacterClass(currentInput, index, character)}
+              className={getCharacterClass(
+                currentInput,
+                index,
+                character,
+                isColorWeaknessUser,
+              )}
             >
               {character}
             </span>

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -7,6 +7,7 @@ import {
   FaUserAlt,
   FaCaretRight,
   FaMedal,
+  FaEye,
 } from 'react-icons/fa';
 import { HiDocumentText } from 'react-icons/hi';
 import { IoSettings } from 'react-icons/io5';
@@ -160,7 +161,7 @@ export default function UserPage() {
                 <span className={cx('userpage__setting__logo')}>
                   <AiFillSound />
                 </span>
-                <span>효과음 출력</span>
+                <span> 효과음 출력</span>
               </div>
               <label>
                 <input
@@ -188,7 +189,7 @@ export default function UserPage() {
                 <span className={cx('userpage__setting__logo')}>
                   <RiCodeBoxFill />
                 </span>
-                <span>언어 설정</span>
+                <span> 언어 설정</span>
               </div>
               <label>
                 <input
@@ -227,7 +228,7 @@ export default function UserPage() {
                 <span className={cx('userpage__setting__logo')}>
                   <HiDocumentText />
                 </span>
-                <span>문제 개수 설정</span>
+                <span> 문제 개수 설정</span>
               </div>
               <label>
                 <input
@@ -263,7 +264,10 @@ export default function UserPage() {
 
             <li className={cx('userpage__setting__item')}>
               <div className={cx('userpage__setting__title')}>
-                <span>색약 모드 설정</span>
+                <span className={cx('userpage__setting__logo')}>
+                  <FaEye />
+                </span>
+                <span> 색약 모드 설정</span>
               </div>
               <label>
                 <input

--- a/src/pages/WordPracticePage.js
+++ b/src/pages/WordPracticePage.js
@@ -1,7 +1,13 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useLayoutEffect,
+} from 'react';
 
 import classNames from 'classnames/bind';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
 import correct from '../audios/correct.mp3';
@@ -9,7 +15,6 @@ import wrong from '../audios/wrong.mp3';
 import Button from '../components/Button';
 import Keyboard from '../components/Keyboard';
 import Modal from '../components/Modal';
-import { unsetPracticeMode } from '../features/userSlice';
 import ModalPortal from '../ModalPortal';
 import checkKoreanInput from '../utils/checkKoreanInput';
 import { keyboardButton, prohibitedKeyCodeList } from '../utils/constants';
@@ -21,12 +26,14 @@ const cx = classNames.bind(styles);
 
 export default function WordPracticePage() {
   const navigate = useNavigate();
-  const dispatch = useDispatch();
 
   const wordList = useSelector((state) => state.problem.wordList);
   const isTurnedOn = useSelector((state) => state.user.soundEffects);
   const name = useSelector((state) => state.user.name);
   const numberProblems = useSelector((state) => state.user.numberProblems);
+  const isColorWeaknessUser = useSelector(
+    (state) => state.user.isColorWeaknessUser,
+  );
 
   const [question, setQuestion] = useState('');
   const [questionLength, setQuestionLength] = useState(0);
@@ -48,17 +55,20 @@ export default function WordPracticePage() {
   const lapsedTime = useRef(0);
   const interval = useRef(null);
 
+  const currentSpanTag = isColorWeaknessUser
+    ? 'currentSpan_colorWeakness'
+    : 'currentSpan';
+
   let currentQuestionId = document.getElementById(questionIndex);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     currentQuestionId = document.getElementById(questionIndex);
 
-    currentQuestionId?.classList.add(cx('currentSpan'));
-
+    currentQuestionId?.classList.add(cx(currentSpanTag));
     return () => {
-      currentQuestionId?.classList.remove(cx('currentSpan'));
+      currentQuestionId?.classList.remove(cx(currentSpanTag));
     };
-  }, [questionIndex]);
+  });
 
   useEffect(() => {
     nextQuestion();
@@ -140,7 +150,7 @@ export default function WordPracticePage() {
       setQuestionIndex((prev) => prev + 1);
       setCurrentInputIndex((prev) => prev + 1);
     } else if (event.keyCode === keyboardButton.backspace) {
-      currentQuestionId.classList.remove(cx('currentSpan'));
+      currentQuestionId.classList.remove(cx(currentSpanTag));
 
       if (questionIndex > 0) {
         setQuestionIndex((prev) => prev - 1);
@@ -151,7 +161,7 @@ export default function WordPracticePage() {
     } else {
       setQuestionIndex((prev) => prev + 1);
       setCurrentInputIndex((prev) => prev + 1);
-      currentQuestionId?.classList.add('current');
+      currentQuestionId?.classList.add(currentSpanTag);
     }
   };
 
@@ -209,7 +219,12 @@ export default function WordPracticePage() {
             <span
               key={index}
               id={index}
-              className={getCharacterClass(currentInput, index, character)}
+              className={getCharacterClass(
+                currentInput,
+                index,
+                character,
+                isColorWeaknessUser,
+              )}
             >
               {character}
             </span>

--- a/src/utils/getCharacterClass.js
+++ b/src/utils/getCharacterClass.js
@@ -1,13 +1,28 @@
-export default function getCharacterClass(currentInput, index, character) {
+export default function getCharacterClass(
+  currentInput,
+  index,
+  character,
+  isColorWeaknessUser,
+) {
   const currentQuestionId = document.getElementById(index);
 
   if (index < currentInput.split('').length) {
     if (character === currentInput.split('')[index]) {
       currentQuestionId?.classList.remove('current');
-      return 'correct';
+
+      if (!isColorWeaknessUser) {
+        return 'correct';
+      } else {
+        return 'correct_colorWeakness';
+      }
     } else {
       currentQuestionId?.classList.remove('current');
-      return 'wrong';
+
+      if (!isColorWeaknessUser) {
+        return 'wrong';
+      } else {
+        return 'wrong_colorWeakness';
+      }
     }
   }
 }


### PR DESCRIPTION
## 코드를 작성한 이유

- 색약모드를 추가했으면 좋겠다는 내부 의견을 통해서 색약모드를 추가했습니다.
- 커서위치 보이는 로직을 조금 변경시켜서 저번보다 유저환경을 업그레이드 시켰습니다.

## 무엇이 변하였는가

- 유저는 my page에서 색약모드 기능을 키거나 끌 수 있습니다. 색약모드(정답과 위치는 파란색, 틀린색은 노란색으로 표시)
- 커서 위치 보이는 로직을 useLayoutEffect를 통해서 바꾸어보았습니다. 
- 탑바 logo버튼 누르면 모달창 속 버튼 위치가 변경되었습니다.

## 작성한 코드에 문제점이 존재하는가

- 현재 DOM을 조작하는 로직이 많습니다. getElementById를 사용하고 싶지 않았는데 useRef를 통해서 도저히 어떻게 로직을 짜야할 지 생각이 안나네요....(현재 단어 위치 보이는 로직)
- useLayoutEffect 또한 최대한 지양하려고 했는데, 좋은 방법이 떠오르지 않아 최후의 보류로 2가지를 선택했습니다. 

## 리뷰 중점사항 

- 리액트에서 DOM조작을 사용할 경우 대체방법을 떠오르기가 정말 너무어렵네요... 다들 좋은 방법이나 피드백 있으면 남겨주시면 감사하겠습니다. 
- 색약모드 관련과 useRef, useEffect vs useLayoutEffect 관련 조사를 착실히 해서 READ.ME 작성할 때 잘 녹여냈으면 좋을 것 같습니다.
