### PR TITLE
긴 글 타자연습 결과창 modal css 수정

### DIFF
--- a/src/pages/ParagraphPracticePage.js
+++ b/src/pages/ParagraphPracticePage.js
@@ -15,7 +15,6 @@ import correct from '../audios/correct.mp3';
 import keyboard from '../audios/keyboard.mp3';
 import wrong from '../audios/wrong.mp3';
 import Button from '../components/Button';
-import Keyboard from '../components/Keyboard';
 import Modal from '../components/Modal';
 import { updateUserRecord } from '../features/userSlice';
 import ModalPortal from '../ModalPortal';
@@ -336,17 +335,31 @@ export default function ParagraphPracticePage({ selectedLanguage, type }) {
         <ModalPortal>
           <Modal
             message={
-              <div>
-                <h1>문장 연습 결과</h1>
-                <p>{name} 님의 연습 결과</p>
-                <p>
-                  정확도: {Math.floor(paragraphAccuracySum / numberProblems)} %
-                </p>
-                <p>
-                  타수: {Math.floor(typingSpeedSum / numberProblems)}타 / 분
-                </p>
-                <p>획득점수: {score} 점</p>
-                <Button onClick={handleButtonClick}>홈으로 이동하기</Button>
+              <div className={cx('practice_result')}>
+                <h1 className={cx('practice_result__title')}>문장 연습 결과</h1>
+                <div className={cx('practice_result__content')}>
+                  <p
+                    className={cx(
+                      'practice_result__content__item',
+                      'practice_result__content__user',
+                    )}
+                  >
+                    {name} 님의 기록은
+                  </p>
+                  <p className={cx('practice_result__content__item')}>
+                    정확도: {Math.floor(paragraphAccuracySum / numberProblems)}{' '}
+                    %
+                  </p>
+                  <p className={cx('practice_result__content__item')}>
+                    타수: {Math.floor(typingSpeedSum / numberProblems)}타 / 분
+                  </p>
+                  <p className={cx('practice_result__content__item')}>
+                    획득점수: {score} 점
+                  </p>
+                </div>
+                <div className={cx('practice_result__button')}>
+                  <Button onClick={handleButtonClick}>홈으로 이동하기</Button>
+                </div>
               </div>
             }
             onCloseModal={setIsShowingModal}


### PR DESCRIPTION
## 코드를 작성한 이유

- 결과창 모달UI를 짧은 글과 똑같이 만들어주기위해서 classname을 작성해 주었습니다.

## 무엇이 변하였는가

- 긴 글 결과창이 기존과 다르게 css가 추가되었습니다.

## 작성한 코드에 문제점이 존재하는가

- 없습니다.

## 리뷰 중점사항 

- css를 추가한 부분이라 리뷰할 부분은 없는 것 같습니다.
