### PR TITLE
긴글 타자연습 뺵틱 겹침 현상 제거를 위해 글자 모양 코드 제거

### DIFF
--- a/src/pages/ParagraphPracticePage.module.scss
+++ b/src/pages/ParagraphPracticePage.module.scss
@@ -21,7 +21,6 @@ $border-color: 2px solid black;
   font-size: 20px;
   box-shadow: 3px 3px rgba(126, 130, 143, 0.8);
   white-space: pre-wrap;
-  font-family: 'Noto Serif', serif;
 
   span {
     padding: 1px;


### PR DESCRIPTION
## 코드를 작성한 이유

- 긴 글 타자연습 문제에서 빽틱과 글자가 겹침 문제가 발생하여 글자 모양으로 인한 문제로 판단되어 글자 모양 scss 제거하였습니다.

## 무엇이 변하였는가

- 긴 글 타자연습 문제 글자 모양이 변경되었습니다.

## 작성한 코드에 문제점이 존재하는가

- 없습니다.

## 리뷰 중점사항 

- 없습니다.
